### PR TITLE
feat: add document library page with reading progress

### DIFF
--- a/backend/internal/documents/service.go
+++ b/backend/internal/documents/service.go
@@ -119,3 +119,13 @@ func (s *Service) DeleteDocument(ctx context.Context, id uuid.UUID) error {
 	// Delete chunk files
 	return s.chunkStore.DeleteDocument(id.String())
 }
+
+// ListDocuments retrieves all documents with their reading progress
+func (s *Service) ListDocuments(ctx context.Context) ([]DocumentWithProgress, error) {
+	return s.repo.List(ctx)
+}
+
+// UpdateDocumentTitle updates the title of a document
+func (s *Service) UpdateDocumentTitle(ctx context.Context, id uuid.UUID, title string) error {
+	return s.repo.UpdateTitle(ctx, id, title)
+}

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -32,8 +32,11 @@ func NewRouter(docService *documents.Service) *chi.Mux {
 		r.Use(MaxBodySize)
 
 		r.Route("/documents", func(r chi.Router) {
+			r.Get("/", handlers.ListDocuments)
 			r.Post("/", handlers.CreateDocument)
 			r.Get("/{id}", handlers.GetDocument)
+			r.Put("/{id}", handlers.UpdateDocument)
+			r.Delete("/{id}", handlers.DeleteDocument)
 			r.Get("/{id}/tokens", handlers.GetTokens)
 			r.Get("/{id}/reading-state", handlers.GetReadingState)
 			r.Put("/{id}/reading-state", handlers.UpdateReadingState)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,12 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { PasteInputView, ReaderView } from './views';
+import { PasteInputView, ReaderView, LibraryView } from './views';
 
 function App() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<PasteInputView />} />
+        <Route path="/library" element={<LibraryView />} />
         <Route path="/read/:id" element={<ReaderView />} />
       </Routes>
     </BrowserRouter>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -47,3 +47,16 @@ export async function put<T, B>(url: string, body: B): Promise<T> {
   });
   return handleResponse<T>(response);
 }
+
+export async function del(url: string): Promise<void> {
+  const response = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+    throw new ApiError(error.error || 'Request failed', response.status);
+  }
+}

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -1,7 +1,9 @@
-import { get, post, put } from './client';
+import { get, post, put, del } from './client';
 import type {
   Document,
+  DocumentWithProgress,
   CreateDocumentRequest,
+  UpdateDocumentRequest,
   ReadingState,
   UpdateReadingStateRequest,
   Chunk,
@@ -9,12 +11,24 @@ import type {
 
 const API_BASE = '/api/documents';
 
+export async function listDocuments(): Promise<DocumentWithProgress[]> {
+  return get<DocumentWithProgress[]>(API_BASE);
+}
+
 export async function createDocument(request: CreateDocumentRequest): Promise<Document> {
   return post<Document, CreateDocumentRequest>(API_BASE, request);
 }
 
 export async function getDocument(id: string): Promise<Document> {
   return get<Document>(`${API_BASE}/${id}`);
+}
+
+export async function updateDocument(id: string, request: UpdateDocumentRequest): Promise<Document> {
+  return put<Document, UpdateDocumentRequest>(`${API_BASE}/${id}`, request);
+}
+
+export async function deleteDocument(id: string): Promise<void> {
+  return del(`${API_BASE}/${id}`);
 }
 
 export async function getTokens(id: string, chunkIndex: number = 0): Promise<Chunk> {

--- a/frontend/src/components/DocumentCard.tsx
+++ b/frontend/src/components/DocumentCard.tsx
@@ -1,0 +1,239 @@
+import { useState, useRef, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { motion, AnimatePresence } from 'motion/react';
+import { Pencil, Trash2, Check, X, BookOpen } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import type { DocumentWithProgress } from '../types';
+
+interface DocumentCardProps {
+  document: DocumentWithProgress;
+  onRename: (id: string, title: string) => Promise<void>;
+  onDelete: (id: string) => Promise<void>;
+  animationDelay?: number;
+}
+
+export function DocumentCard({ document, onRename, onDelete, animationDelay = 0 }: DocumentCardProps) {
+  const navigate = useNavigate();
+  const [isEditing, setIsEditing] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [editTitle, setEditTitle] = useState(document.title);
+  const [isLoading, setIsLoading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const progress = document.tokenCount > 0
+    ? (document.tokenIndex / document.tokenCount) * 100
+    : 0;
+
+  const isCompleted = progress >= 99;
+  const hasStarted = document.tokenIndex > 0;
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const handleSaveRename = async () => {
+    if (!editTitle.trim() || editTitle === document.title) {
+      setIsEditing(false);
+      setEditTitle(document.title);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await onRename(document.id, editTitle.trim());
+      setIsEditing(false);
+    } catch {
+      setEditTitle(document.title);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleCancelRename = () => {
+    setEditTitle(document.title);
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSaveRename();
+    } else if (e.key === 'Escape') {
+      handleCancelRename();
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    setIsLoading(true);
+    try {
+      await onDelete(document.id);
+    } finally {
+      setIsLoading(false);
+      setIsDeleting(false);
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: date.getFullYear() !== new Date().getFullYear() ? 'numeric' : undefined,
+    });
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4, delay: animationDelay, ease: 'easeOut' }}
+      className="relative group"
+    >
+      <div className="bg-bg-elevated border border-border rounded-xl overflow-hidden hover:border-amber-500/30 transition-colors">
+        <AnimatePresence mode="wait">
+          {isDeleting ? (
+            <motion.div
+              key="delete-confirm"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="p-5 flex flex-col items-center justify-center min-h-[180px] gap-4"
+            >
+              <p className="text-text-secondary text-sm text-center">
+                Delete "{document.title}"?
+              </p>
+              <div className="flex gap-3">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsDeleting(false)}
+                  disabled={isLoading}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleConfirmDelete}
+                  disabled={isLoading}
+                >
+                  {isLoading ? 'Deleting...' : 'Delete'}
+                </Button>
+              </div>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="card-content"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+            >
+              <div className="p-5">
+                <div className="flex items-start justify-between gap-3 mb-4">
+                  {isEditing ? (
+                    <div className="flex-1 flex items-center gap-2">
+                      <Input
+                        ref={inputRef}
+                        value={editTitle}
+                        onChange={(e) => setEditTitle(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        disabled={isLoading}
+                        className="h-8 text-base"
+                      />
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={handleSaveRename}
+                        disabled={isLoading}
+                        className="h-8 w-8 text-green-500 hover:text-green-400 hover:bg-green-500/10"
+                      >
+                        <Check className="w-4 h-4" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={handleCancelRename}
+                        disabled={isLoading}
+                        className="h-8 w-8 text-text-tertiary hover:text-text-secondary"
+                      >
+                        <X className="w-4 h-4" />
+                      </Button>
+                    </div>
+                  ) : (
+                    <>
+                      <h3
+                        className="font-serif font-medium text-text-primary text-lg leading-tight line-clamp-2 cursor-pointer hover:text-amber-400 transition-colors"
+                        onClick={() => navigate(`/read/${document.id}`)}
+                      >
+                        {document.title}
+                      </h3>
+                      <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={() => setIsEditing(true)}
+                          className="h-7 w-7 text-text-tertiary hover:text-amber-400"
+                        >
+                          <Pencil className="w-3.5 h-3.5" />
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={() => setIsDeleting(true)}
+                          className="h-7 w-7 text-text-tertiary hover:text-destructive"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </Button>
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2 text-xs text-text-tertiary font-counter mb-4">
+                  <span>{document.tokenCount.toLocaleString()} words</span>
+                  <span className="text-border">•</span>
+                  <span>{document.wpm} WPM</span>
+                  <span className="text-border">•</span>
+                  <span>{formatDate(document.updatedAt)}</span>
+                </div>
+
+                <div className="space-y-2">
+                  <div className="h-1.5 bg-bg-surface rounded-full overflow-hidden">
+                    <motion.div
+                      initial={{ width: 0 }}
+                      animate={{ width: `${progress}%` }}
+                      transition={{ duration: 0.6, delay: animationDelay + 0.2, ease: 'easeOut' }}
+                      className="h-full bg-amber-500 rounded-full shadow-[0_0_8px_rgba(240,166,35,0.4)]"
+                    />
+                  </div>
+                  <div className="flex items-center justify-between text-xs font-counter">
+                    <span className="text-text-tertiary">
+                      {hasStarted ? `${Math.round(progress)}% complete` : 'Not started'}
+                    </span>
+                    {isCompleted && (
+                      <span className="text-green-500 flex items-center gap-1">
+                        <Check className="w-3 h-3" />
+                        Finished
+                      </span>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              <button
+                onClick={() => navigate(`/read/${document.id}`)}
+                className="w-full px-5 py-3 bg-bg-surface border-t border-border flex items-center justify-center gap-2 text-sm font-medium text-text-secondary hover:text-amber-400 hover:bg-bg-surface/80 transition-colors"
+              >
+                <BookOpen className="w-4 h-4" />
+                {hasStarted ? 'Continue Reading' : 'Start Reading'}
+              </button>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </motion.div>
+  );
+}

--- a/frontend/src/components/ProgressBar.tsx
+++ b/frontend/src/components/ProgressBar.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useRef } from 'react';
+import { TimerDisplay } from './TimerDisplay';
 
 interface ProgressBarProps {
   current: number;
   total: number;
   onSeek: (position: number) => void;
+  elapsedTime?: string;
+  totalTime?: string;
 }
 
-export function ProgressBar({ current, total, onSeek }: ProgressBarProps) {
+export function ProgressBar({ current, total, onSeek, elapsedTime, totalTime }: ProgressBarProps) {
   const progressRef = useRef<HTMLDivElement>(null);
 
   const progress = total > 0 ? (current / total) * 100 : 0;
@@ -46,8 +49,9 @@ export function ProgressBar({ current, total, onSeek }: ProgressBarProps) {
           style={{ left: `${progress}%` }}
         />
       </div>
-      <div className="mt-2 text-center text-sm font-counter text-text-tertiary">
-        {formatProgress()}
+      <div className="mt-2 flex items-center justify-between text-sm font-counter text-text-tertiary px-1">
+        <TimerDisplay elapsed={elapsedTime || '0:00'} total={totalTime || '0:00'} />
+        <div className="tabular-nums">{formatProgress()}</div>
       </div>
     </div>
   );

--- a/frontend/src/components/TimerDisplay.tsx
+++ b/frontend/src/components/TimerDisplay.tsx
@@ -1,0 +1,14 @@
+interface TimerDisplayProps {
+  elapsed: string;
+  total: string;
+}
+
+export function TimerDisplay({ elapsed, total }: TimerDisplayProps) {
+  return (
+    <div className="flex items-center gap-1.5 text-sm font-counter text-text-tertiary tabular-nums">
+      <span className="text-amber-400">{elapsed}</span>
+      <span>/</span>
+      <span>{total}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,3 +1,4 @@
 export { RSVPDisplay } from './RSVPDisplay';
 export { ControlBar } from './ControlBar';
 export { ProgressBar } from './ProgressBar';
+export { TimerDisplay } from './TimerDisplay';

--- a/frontend/src/engine/RSVPEngine.ts
+++ b/frontend/src/engine/RSVPEngine.ts
@@ -68,6 +68,10 @@ export class RSVPEngine {
     return this.totalTokens;
   }
 
+  getAllLoadedTokens(): Token[] {
+    return this.tokens;
+  }
+
   play(): void {
     if (this.isPlaying || this.tokens.length === 0) return;
 

--- a/frontend/src/hooks/useReadingTimer.ts
+++ b/frontend/src/hooks/useReadingTimer.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import type { Token } from '../types';
+import {
+  calculateElapsedTime,
+  estimateTotalTime,
+  formatDuration,
+} from '../utils/timer';
+
+interface UseReadingTimerProps {
+  tokens: Token[];
+  currentIndex: number;
+  totalTokens: number;
+  wpm: number;
+}
+
+interface UseReadingTimerResult {
+  elapsedFormatted: string;
+  totalFormatted: string;
+  elapsedMs: number;
+  totalMs: number;
+}
+
+export function useReadingTimer({
+  tokens,
+  currentIndex,
+  totalTokens,
+  wpm,
+}: UseReadingTimerProps): UseReadingTimerResult {
+  const elapsedMs = useMemo(() => {
+    if (tokens.length === 0 || currentIndex <= 0) {
+      return 0;
+    }
+    return calculateElapsedTime(tokens, currentIndex, wpm);
+  }, [tokens, currentIndex, wpm]);
+
+  // Total time only depends on tokens and WPM, not current position
+  const totalMs = useMemo(() => {
+    if (tokens.length === 0) {
+      return 0;
+    }
+    return estimateTotalTime(tokens, totalTokens, wpm);
+  }, [tokens, totalTokens, wpm]);
+
+  const elapsedFormatted = useMemo(() => formatDuration(elapsedMs), [elapsedMs]);
+  const totalFormatted = useMemo(() => formatDuration(totalMs), [totalMs]);
+
+  return {
+    elapsedFormatted,
+    totalFormatted,
+    elapsedMs,
+    totalMs,
+  };
+}

--- a/frontend/src/types/document.ts
+++ b/frontend/src/types/document.ts
@@ -27,3 +27,13 @@ export interface UpdateReadingStateRequest {
   wpm: number;
   chunkSize: number;
 }
+
+export interface DocumentWithProgress extends Document {
+  tokenIndex: number;
+  wpm: number;
+  updatedAt: string;
+}
+
+export interface UpdateDocumentRequest {
+  title: string;
+}

--- a/frontend/src/utils/timer.ts
+++ b/frontend/src/utils/timer.ts
@@ -1,0 +1,92 @@
+import type { Token } from '../types';
+
+/**
+ * Calculate the display time for a single token based on WPM and difficulty.
+ * Difficulty is determined by pause multiplier (punctuation) and word length.
+ */
+export function calculateTokenTime(token: Token, wpm: number): number {
+  const baseDelayMs = 60000 / wpm;
+  const pauseMultiplier = token.pauseMultiplier || 1;
+  const lengthMultiplier = Math.max(1, token.text.length / 5);
+
+  return baseDelayMs * pauseMultiplier * lengthMultiplier;
+}
+
+/**
+ * Calculate the total reading time for a range of tokens.
+ */
+export function calculateReadingTime(
+  tokens: Token[],
+  wpm: number,
+  from: number = 0,
+  to?: number
+): number {
+  const end = to ?? tokens.length;
+  let totalMs = 0;
+
+  for (let i = from; i < end && i < tokens.length; i++) {
+    totalMs += calculateTokenTime(tokens[i], wpm);
+  }
+
+  return totalMs;
+}
+
+/**
+ * Estimate total reading time for the entire document.
+ * Uses average token time from loaded tokens to estimate unloaded portions.
+ */
+export function estimateTotalTime(
+  loadedTokens: Token[],
+  totalTokens: number,
+  wpm: number
+): number {
+  if (loadedTokens.length === 0 || totalTokens === 0) {
+    return 0;
+  }
+
+  // Calculate time for all loaded tokens
+  const loadedTime = calculateReadingTime(loadedTokens, wpm);
+
+  // Estimate time for unloaded tokens
+  const unloadedTokenCount = totalTokens - loadedTokens.length;
+  if (unloadedTokenCount <= 0) {
+    return loadedTime;
+  }
+
+  // Calculate average time per loaded token to estimate unloaded tokens
+  const avgTimePerToken = loadedTime / loadedTokens.length;
+  const estimatedUnloadedTime = unloadedTokenCount * avgTimePerToken;
+
+  return loadedTime + estimatedUnloadedTime;
+}
+
+/**
+ * Calculate elapsed time from start to current position.
+ */
+export function calculateElapsedTime(
+  tokens: Token[],
+  currentIndex: number,
+  wpm: number
+): number {
+  return calculateReadingTime(tokens, wpm, 0, currentIndex);
+}
+
+/**
+ * Format milliseconds as a duration string (M:SS or H:MM:SS).
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 0 || !Number.isFinite(ms)) {
+    return '0:00';
+  }
+
+  const totalSeconds = Math.round(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+  }
+
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -1,0 +1,137 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'motion/react';
+import { Plus, Library, FileText } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { DocumentCard } from '../components/DocumentCard';
+import { listDocuments, updateDocument, deleteDocument } from '../api';
+import type { DocumentWithProgress } from '../types';
+
+export function LibraryView() {
+  const navigate = useNavigate();
+  const [documents, setDocuments] = useState<DocumentWithProgress[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchDocuments = useCallback(async () => {
+    try {
+      const docs = await listDocuments();
+      setDocuments(docs || []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load documents');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchDocuments();
+  }, [fetchDocuments]);
+
+  const handleRename = async (id: string, title: string) => {
+    await updateDocument(id, { title });
+    setDocuments((prev) =>
+      prev.map((doc) => (doc.id === id ? { ...doc, title } : doc))
+    );
+  };
+
+  const handleDelete = async (id: string) => {
+    await deleteDocument(id);
+    setDocuments((prev) => prev.filter((doc) => doc.id !== id));
+  };
+
+  return (
+    <div className="min-h-screen bg-warm-gradient bg-grain">
+      <header className="sticky top-0 z-10 bg-bg-base/80 backdrop-blur-md border-b border-border">
+        <div className="max-w-6xl mx-auto px-4 md:px-8 py-4 flex items-center justify-between">
+          <motion.div
+            initial={{ opacity: 0, x: -12 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.4 }}
+            className="flex items-center gap-3"
+          >
+            <button
+              onClick={() => navigate('/')}
+              className="p-1 -m-1 rounded-lg hover:bg-bg-elevated transition-colors"
+              aria-label="Go to new document"
+            >
+              <Library className="w-6 h-6 text-amber-400" />
+            </button>
+            <h1 className="text-xl md:text-2xl font-serif font-semibold text-text-primary">
+              My Library
+            </h1>
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0, x: 12 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.4 }}
+          >
+            <Button
+              onClick={() => navigate('/')}
+              className="gap-2"
+            >
+              <Plus className="w-4 h-4" />
+              New Document
+            </Button>
+          </motion.div>
+        </div>
+      </header>
+
+      <main className="max-w-6xl mx-auto px-4 md:px-8 py-8 relative z-10">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-20">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="text-text-tertiary"
+            >
+              Loading documents...
+            </motion.div>
+          </div>
+        ) : error ? (
+          <motion.div
+            initial={{ opacity: 0, scale: 0.98 }}
+            animate={{ opacity: 1, scale: 1 }}
+            className="p-4 bg-destructive/10 border border-destructive/30 rounded-lg text-destructive text-sm text-center"
+          >
+            {error}
+          </motion.div>
+        ) : documents.length === 0 ? (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5 }}
+            className="flex flex-col items-center justify-center py-20 text-center"
+          >
+            <div className="w-20 h-20 rounded-full bg-bg-elevated flex items-center justify-center mb-6">
+              <FileText className="w-10 h-10 text-text-tertiary" />
+            </div>
+            <h2 className="text-xl font-serif font-medium text-text-primary mb-2">
+              No documents yet
+            </h2>
+            <p className="text-text-secondary mb-6 max-w-sm">
+              Create your first document to start speed reading. Paste any text and let the reader help you absorb it faster.
+            </p>
+            <Button onClick={() => navigate('/')} className="gap-2">
+              <Plus className="w-4 h-4" />
+              Create Your First Document
+            </Button>
+          </motion.div>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 md:gap-6">
+            {documents.map((doc, index) => (
+              <DocumentCard
+                key={doc.id}
+                document={doc}
+                onRename={handleRename}
+                onDelete={handleDelete}
+                animationDelay={index * 0.08}
+              />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/views/PasteInputView.tsx
+++ b/frontend/src/views/PasteInputView.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion } from 'motion/react';
+import { Library } from 'lucide-react';
 import { createDocument } from '../api';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -48,7 +49,9 @@ export function PasteInputView() {
               initial={{ opacity: 0, y: 12 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, ease: 'easeOut' }}
+              className="flex items-center justify-center gap-3"
             >
+              <Library className="w-10 h-10 md:w-12 md:h-12 text-amber-400" />
               <CardTitle className="text-4xl md:text-5xl font-serif font-semibold bg-gradient-to-r from-amber-300 via-amber-400 to-amber-500 bg-clip-text text-transparent">
                 Speed Reader
               </CardTitle>
@@ -61,6 +64,21 @@ export function PasteInputView() {
               <CardDescription className="text-text-secondary text-base mt-2 font-serif italic">
                 Paste your text below to begin
               </CardDescription>
+            </motion.div>
+            <motion.div
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.5, delay: 0.15, ease: 'easeOut' }}
+              className="mt-4"
+            >
+              <Button
+                variant="outline"
+                onClick={() => navigate('/library')}
+                className="gap-2"
+              >
+                <Library className="w-4 h-4" />
+                My Library
+              </Button>
             </motion.div>
           </CardHeader>
 

--- a/frontend/src/views/index.ts
+++ b/frontend/src/views/index.ts
@@ -1,2 +1,3 @@
 export { PasteInputView } from './PasteInputView';
 export { ReaderView } from './ReaderView';
+export { LibraryView } from './LibraryView';


### PR DESCRIPTION
- Add backend API endpoints: GET /api/documents (list with progress), PUT /api/documents/:id (rename), DELETE /api/documents/:id
- Create LibraryView with responsive grid layout and staggered animations
- Create DocumentCard with progress bar, inline rename, delete confirmation
- Add Library icon as site logo, clickable navigation between views
- Add timer utilities for elapsed/remaining time display