### PR TITLE
feat: add Google OAuth authentication with guest users and document sharing

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,3 +6,21 @@ DATABASE_URL=postgres://speedreader:speedreader@localhost:5432/speedreader?sslmo
 
 # Storage path for document chunks
 STORAGE_PATH=./data
+
+# Authentication
+JWT_SECRET=your-256-bit-secret-change-in-production
+CSRF_SECRET=your-256-bit-csrf-secret-change-in-production
+
+# Google OAuth (get from Google Cloud Console)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URL=http://localhost:8080/api/auth/google/callback
+
+# Frontend URL for redirects
+FRONTEND_URL=http://localhost:5173
+
+# Guest document expiration (days)
+GUEST_DOC_TTL_DAYS=30
+
+# Set to true in production with HTTPS
+SECURE_COOKIE=false

--- a/backend/cmd/cleanup/main.go
+++ b/backend/cmd/cleanup/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"github.com/mikepersonal/speed-reader/backend/internal/config"
+	"github.com/mikepersonal/speed-reader/backend/internal/documents"
+	"github.com/mikepersonal/speed-reader/backend/internal/storage"
+)
+
+func main() {
+	log.Println("Starting document cleanup job...")
+	startTime := time.Now()
+
+	// Load configuration
+	cfg := config.Load()
+
+	// Connect to database
+	db, err := sql.Open("postgres", cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("Failed to connect to database: %v", err)
+	}
+	defer db.Close()
+
+	// Verify database connection
+	if err := db.Ping(); err != nil {
+		log.Fatalf("Failed to ping database: %v", err)
+	}
+
+	// Initialize services
+	chunkStore := storage.NewChunkStore(cfg.StoragePath)
+	docRepo := documents.NewRepository(db)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	// Delete expired documents from database
+	deletedIDs, err := docRepo.DeleteExpiredGuestDocuments(ctx)
+	if err != nil {
+		log.Fatalf("Failed to delete expired documents: %v", err)
+	}
+
+	log.Printf("Deleted %d expired documents from database", len(deletedIDs))
+
+	// Delete chunk files for each deleted document
+	var chunkDeleteErrors int
+	for _, id := range deletedIDs {
+		if err := chunkStore.DeleteDocument(id.String()); err != nil {
+			log.Printf("Warning: failed to delete chunks for document %s: %v", id, err)
+			chunkDeleteErrors++
+		}
+	}
+
+	duration := time.Since(startTime)
+	log.Printf("Cleanup completed in %v", duration)
+	log.Printf("Summary: %d documents deleted, %d chunk deletion errors", len(deletedIDs), chunkDeleteErrors)
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,13 @@ go 1.20
 require (
 	github.com/go-chi/chi/v5 v5.0.12
 	github.com/go-chi/cors v1.2.2
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.10.9
+	golang.org/x/oauth2 v0.21.0
+)
+
+require (
+	cloud.google.com/go/compute/metadata v0.3.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,8 +1,17 @@
+cloud.google.com/go/compute/metadata v0.3.0 h1:Tz+eQXMEqDIKRsmY3cHTL6FVaynIjX2QxYC4trgAKZc=
+cloud.google.com/go/compute/metadata v0.3.0/go.mod h1:zFmK7XCadkQkj6TtorcaGlCW1hT1fIilQDwofLpJ20k=
 github.com/go-chi/chi/v5 v5.0.12 h1:9euLV5sTrTNTRUU9POmDUvfxyj6LAABLUcEWO+JJb4s=
 github.com/go-chi/chi/v5 v5.0.12/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
 github.com/go-chi/cors v1.2.2 h1:Jmey33TE+b+rB7fT8MUy1u0I4L+NARQlK6LhzKPSyQE=
 github.com/go-chi/cors v1.2.2/go.mod h1:sSbTewc+6wYHBBCW7ytsFSn836hqM7JxpglAy2Vzc58=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+golang.org/x/oauth2 v0.21.0 h1:tsimM75w1tF/uws5rbeHzIWxEqElMehnc+iW793zsZs=
+golang.org/x/oauth2 v0.21.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=

--- a/backend/internal/auth/context.go
+++ b/backend/internal/auth/context.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+type contextKey string
+
+const (
+	userContextKey   contextKey = "user"
+	userIDContextKey contextKey = "userID"
+)
+
+// ContextWithUser adds a user to the context
+func ContextWithUser(ctx context.Context, user *User) context.Context {
+	ctx = context.WithValue(ctx, userContextKey, user)
+	ctx = context.WithValue(ctx, userIDContextKey, user.ID)
+	return ctx
+}
+
+// UserFromContext extracts the user from the context
+func UserFromContext(ctx context.Context) (*User, bool) {
+	user, ok := ctx.Value(userContextKey).(*User)
+	return user, ok
+}
+
+// UserIDFromContext extracts the user ID from the context
+func UserIDFromContext(ctx context.Context) (uuid.UUID, bool) {
+	id, ok := ctx.Value(userIDContextKey).(uuid.UUID)
+	return id, ok
+}
+
+// MustUserIDFromContext extracts the user ID from the context or panics
+func MustUserIDFromContext(ctx context.Context) uuid.UUID {
+	id, ok := UserIDFromContext(ctx)
+	if !ok {
+		panic("user ID not found in context")
+	}
+	return id
+}

--- a/backend/internal/auth/csrf.go
+++ b/backend/internal/auth/csrf.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"time"
+)
+
+const (
+	// CSRFTokenDuration is the lifetime of a CSRF token
+	CSRFTokenDuration = 1 * time.Hour
+)
+
+// CSRFManager handles CSRF token operations
+type CSRFManager struct {
+	secret []byte
+}
+
+// NewCSRFManager creates a new CSRF manager
+func NewCSRFManager(secret string) *CSRFManager {
+	return &CSRFManager{secret: []byte(secret)}
+}
+
+// GenerateToken generates a new CSRF token
+func (m *CSRFManager) GenerateToken() (string, error) {
+	// Generate random bytes
+	randomBytes := make([]byte, 32)
+	if _, err := rand.Read(randomBytes); err != nil {
+		return "", fmt.Errorf("failed to generate random bytes: %w", err)
+	}
+
+	// Create timestamp (for optional expiration checking)
+	timestamp := time.Now().Unix()
+	message := append(randomBytes, byte(timestamp>>56), byte(timestamp>>48), byte(timestamp>>40), byte(timestamp>>32),
+		byte(timestamp>>24), byte(timestamp>>16), byte(timestamp>>8), byte(timestamp))
+
+	// Create HMAC signature
+	mac := hmac.New(sha256.New, m.secret)
+	mac.Write(message)
+	signature := mac.Sum(nil)
+
+	// Combine message and signature
+	token := append(message, signature...)
+	return base64.URLEncoding.EncodeToString(token), nil
+}
+
+// ValidateToken validates a CSRF token
+func (m *CSRFManager) ValidateToken(tokenString string) bool {
+	token, err := base64.URLEncoding.DecodeString(tokenString)
+	if err != nil {
+		return false
+	}
+
+	// Token must be at least 40 bytes (32 random + 8 timestamp) + 32 bytes signature
+	if len(token) < 72 {
+		return false
+	}
+
+	// Split message and signature
+	message := token[:40]
+	providedSignature := token[40:]
+
+	// Verify signature
+	mac := hmac.New(sha256.New, m.secret)
+	mac.Write(message)
+	expectedSignature := mac.Sum(nil)
+
+	if !hmac.Equal(providedSignature, expectedSignature) {
+		return false
+	}
+
+	// Optionally check expiration (extract timestamp from message)
+	timestamp := int64(message[32])<<56 | int64(message[33])<<48 | int64(message[34])<<40 | int64(message[35])<<32 |
+		int64(message[36])<<24 | int64(message[37])<<16 | int64(message[38])<<8 | int64(message[39])
+
+	if time.Unix(timestamp, 0).Add(CSRFTokenDuration).Before(time.Now()) {
+		return false
+	}
+
+	return true
+}

--- a/backend/internal/auth/google.go
+++ b/backend/internal/auth/google.go
@@ -1,0 +1,89 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+)
+
+// GoogleUserInfo represents the user info returned by Google
+type GoogleUserInfo struct {
+	ID            string `json:"id"`
+	Email         string `json:"email"`
+	VerifiedEmail bool   `json:"verified_email"`
+	Name          string `json:"name"`
+	GivenName     string `json:"given_name"`
+	FamilyName    string `json:"family_name"`
+	Picture       string `json:"picture"`
+}
+
+// GoogleOAuth handles Google OAuth2 operations
+type GoogleOAuth struct {
+	config *oauth2.Config
+}
+
+// NewGoogleOAuth creates a new Google OAuth client
+func NewGoogleOAuth(clientID, clientSecret, redirectURL string) *GoogleOAuth {
+	return &GoogleOAuth{
+		config: &oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			RedirectURL:  redirectURL,
+			Scopes: []string{
+				"https://www.googleapis.com/auth/userinfo.email",
+				"https://www.googleapis.com/auth/userinfo.profile",
+			},
+			Endpoint: google.Endpoint,
+		},
+	}
+}
+
+// GetAuthURL returns the URL for the OAuth consent screen
+func (g *GoogleOAuth) GetAuthURL(state string) string {
+	return g.config.AuthCodeURL(state, oauth2.AccessTypeOffline)
+}
+
+// ExchangeCode exchanges an authorization code for tokens
+func (g *GoogleOAuth) ExchangeCode(ctx context.Context, code string) (*oauth2.Token, error) {
+	token, err := g.config.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("failed to exchange code: %w", err)
+	}
+	return token, nil
+}
+
+// GetUserInfo fetches the user's profile information from Google
+func (g *GoogleOAuth) GetUserInfo(ctx context.Context, token *oauth2.Token) (*GoogleUserInfo, error) {
+	client := g.config.Client(ctx, token)
+
+	resp, err := client.Get("https://www.googleapis.com/oauth2/v2/userinfo")
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch user info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to fetch user info: status %d", resp.StatusCode)
+	}
+
+	var userInfo GoogleUserInfo
+	if err := json.NewDecoder(resp.Body).Decode(&userInfo); err != nil {
+		return nil, fmt.Errorf("failed to decode user info: %w", err)
+	}
+
+	return &userInfo, nil
+}
+
+// ToCreateOAuthUserParams converts Google user info to OAuth params
+func (g *GoogleUserInfo) ToCreateOAuthUserParams() *CreateOAuthUserParams {
+	return &CreateOAuthUserParams{
+		Email:     g.Email,
+		GoogleID:  g.ID,
+		Name:      g.Name,
+		AvatarURL: g.Picture,
+	}
+}

--- a/backend/internal/auth/handlers.go
+++ b/backend/internal/auth/handlers.go
@@ -1,0 +1,205 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+const (
+	// RefreshTokenCookieName is the name of the refresh token cookie
+	RefreshTokenCookieName = "refresh_token"
+
+	// CSRFTokenCookieName is the name of the CSRF token cookie
+	CSRFTokenCookieName = "csrf_token"
+)
+
+// Handlers contains HTTP handlers for auth
+type Handlers struct {
+	service     *Service
+	frontendURL string
+	secureCookie bool
+}
+
+// NewHandlers creates a new auth Handlers instance
+func NewHandlers(service *Service, frontendURL string, secureCookie bool) *Handlers {
+	return &Handlers{
+		service:     service,
+		frontendURL: frontendURL,
+		secureCookie: secureCookie,
+	}
+}
+
+// ErrorResponse represents an error response
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// writeJSON writes a JSON response
+func writeJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(data)
+}
+
+// writeError writes an error response
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, ErrorResponse{Error: message})
+}
+
+// setRefreshTokenCookie sets the refresh token cookie
+func (h *Handlers) setRefreshTokenCookie(w http.ResponseWriter, token string, expiresAt time.Time) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     RefreshTokenCookieName,
+		Value:    token,
+		Path:     "/api/auth",
+		Expires:  expiresAt,
+		HttpOnly: true,
+		Secure:   h.secureCookie,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// clearRefreshTokenCookie clears the refresh token cookie
+func (h *Handlers) clearRefreshTokenCookie(w http.ResponseWriter) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     RefreshTokenCookieName,
+		Value:    "",
+		Path:     "/api/auth",
+		Expires:  time.Unix(0, 0),
+		HttpOnly: true,
+		Secure:   h.secureCookie,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// setCSRFTokenCookie sets the CSRF token cookie (readable by JavaScript)
+func (h *Handlers) setCSRFTokenCookie(w http.ResponseWriter, token string) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     CSRFTokenCookieName,
+		Value:    token,
+		Path:     "/",
+		Expires:  time.Now().Add(CSRFTokenDuration),
+		HttpOnly: false, // Must be readable by JavaScript
+		Secure:   h.secureCookie,
+		SameSite: http.SameSiteLaxMode,
+	})
+}
+
+// CreateGuest handles POST /api/auth/guest
+func (h *Handlers) CreateGuest(w http.ResponseWriter, r *http.Request) {
+	authResponse, refreshToken, err := h.service.CreateGuestUser(r.Context())
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to create guest user")
+		return
+	}
+
+	// Set refresh token cookie
+	h.setRefreshTokenCookie(w, refreshToken, time.Now().Add(RefreshTokenDuration))
+
+	// Generate and set CSRF token
+	csrfToken, err := h.service.GenerateCSRFToken()
+	if err == nil {
+		h.setCSRFTokenCookie(w, csrfToken)
+	}
+
+	writeJSON(w, http.StatusCreated, authResponse)
+}
+
+// GoogleLogin handles GET /api/auth/google
+func (h *Handlers) GoogleLogin(w http.ResponseWriter, r *http.Request) {
+	// Check if there's a current guest user to merge
+	var url string
+	if user, ok := UserFromContext(r.Context()); ok && user.IsGuest {
+		userID := user.ID
+		url = h.service.GetGoogleAuthURL(&userID)
+	} else {
+		url = h.service.GetGoogleAuthURL(nil)
+	}
+
+	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+}
+
+// GoogleCallback handles GET /api/auth/google/callback
+func (h *Handlers) GoogleCallback(w http.ResponseWriter, r *http.Request) {
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Redirect(w, r, h.frontendURL+"?error=missing_code", http.StatusTemporaryRedirect)
+		return
+	}
+
+	state := r.URL.Query().Get("state")
+
+	authResponse, refreshToken, err := h.service.HandleGoogleCallback(r.Context(), code, state)
+	if err != nil {
+		http.Redirect(w, r, h.frontendURL+"?error=auth_failed", http.StatusTemporaryRedirect)
+		return
+	}
+
+	// Set refresh token cookie
+	h.setRefreshTokenCookie(w, refreshToken, time.Now().Add(RefreshTokenDuration))
+
+	// Generate and set CSRF token
+	csrfToken, err := h.service.GenerateCSRFToken()
+	if err == nil {
+		h.setCSRFTokenCookie(w, csrfToken)
+	}
+
+	// Redirect to frontend with access token in URL fragment (more secure than query params)
+	redirectURL := h.frontendURL + "/auth/callback#token=" + authResponse.Token
+	http.Redirect(w, r, redirectURL, http.StatusTemporaryRedirect)
+}
+
+// Refresh handles POST /api/auth/refresh
+func (h *Handlers) Refresh(w http.ResponseWriter, r *http.Request) {
+	// Get refresh token from cookie
+	cookie, err := r.Cookie(RefreshTokenCookieName)
+	if err != nil {
+		writeError(w, http.StatusUnauthorized, "missing refresh token")
+		return
+	}
+
+	authResponse, newRefreshToken, err := h.service.RefreshAccessToken(r.Context(), cookie.Value)
+	if err != nil {
+		h.clearRefreshTokenCookie(w)
+		writeError(w, http.StatusUnauthorized, "invalid or expired refresh token")
+		return
+	}
+
+	// Set new refresh token cookie
+	h.setRefreshTokenCookie(w, newRefreshToken, time.Now().Add(RefreshTokenDuration))
+
+	// Generate and set new CSRF token
+	csrfToken, err := h.service.GenerateCSRFToken()
+	if err == nil {
+		h.setCSRFTokenCookie(w, csrfToken)
+	}
+
+	writeJSON(w, http.StatusOK, authResponse)
+}
+
+// Logout handles POST /api/auth/logout
+func (h *Handlers) Logout(w http.ResponseWriter, r *http.Request) {
+	// Get user from context
+	user, ok := UserFromContext(r.Context())
+	if ok {
+		// Delete all refresh tokens for user
+		_ = h.service.Logout(r.Context(), user.ID)
+	}
+
+	// Clear cookies
+	h.clearRefreshTokenCookie(w)
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Me handles GET /api/auth/me
+func (h *Handlers) Me(w http.ResponseWriter, r *http.Request) {
+	user, ok := UserFromContext(r.Context())
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "not authenticated")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, user)
+}

--- a/backend/internal/auth/jwt.go
+++ b/backend/internal/auth/jwt.go
@@ -1,0 +1,94 @@
+package auth
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
+)
+
+const (
+	// AccessTokenDuration is the lifetime of an access token
+	AccessTokenDuration = 15 * time.Minute
+
+	// RefreshTokenDuration is the lifetime of a refresh token
+	RefreshTokenDuration = 7 * 24 * time.Hour
+)
+
+// JWTClaims represents the claims in a JWT
+type JWTClaims struct {
+	UserID  string `json:"uid"`
+	IsGuest bool   `json:"guest"`
+	jwt.RegisteredClaims
+}
+
+// JWTManager handles JWT operations
+type JWTManager struct {
+	secret []byte
+}
+
+// NewJWTManager creates a new JWT manager
+func NewJWTManager(secret string) *JWTManager {
+	return &JWTManager{secret: []byte(secret)}
+}
+
+// GenerateAccessToken generates a new access token for a user
+func (m *JWTManager) GenerateAccessToken(user *User) (string, time.Time, error) {
+	expiresAt := time.Now().Add(AccessTokenDuration)
+
+	claims := &JWTClaims{
+		UserID:  user.ID.String(),
+		IsGuest: user.IsGuest,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(expiresAt),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			Subject:   user.ID.String(),
+		},
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signedToken, err := token.SignedString(m.secret)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("failed to sign access token: %w", err)
+	}
+
+	return signedToken, expiresAt, nil
+}
+
+// ValidateAccessToken validates an access token and returns the claims
+func (m *JWTManager) ValidateAccessToken(tokenString string) (*JWTClaims, error) {
+	token, err := jwt.ParseWithClaims(tokenString, &JWTClaims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return m.secret, nil
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse token: %w", err)
+	}
+
+	claims, ok := token.Claims.(*JWTClaims)
+	if !ok || !token.Valid {
+		return nil, fmt.Errorf("invalid token claims")
+	}
+
+	return claims, nil
+}
+
+// GetUserIDFromClaims extracts the user ID from JWT claims
+func GetUserIDFromClaims(claims *JWTClaims) (uuid.UUID, error) {
+	return uuid.Parse(claims.UserID)
+}
+
+// GenerateRefreshToken generates a secure random refresh token
+func GenerateRefreshToken() (string, error) {
+	bytes := make([]byte, 32)
+	if _, err := rand.Read(bytes); err != nil {
+		return "", fmt.Errorf("failed to generate refresh token: %w", err)
+	}
+	return base64.URLEncoding.EncodeToString(bytes), nil
+}

--- a/backend/internal/auth/middleware.go
+++ b/backend/internal/auth/middleware.go
@@ -1,0 +1,133 @@
+package auth
+
+import (
+	"net/http"
+	"strings"
+)
+
+// RequireAuth middleware requires a valid access token
+func RequireAuth(service *Service) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Extract token from Authorization header
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				http.Error(w, `{"error":"missing authorization header"}`, http.StatusUnauthorized)
+				return
+			}
+
+			// Expect "Bearer <token>"
+			parts := strings.SplitN(authHeader, " ", 2)
+			if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+				http.Error(w, `{"error":"invalid authorization header format"}`, http.StatusUnauthorized)
+				return
+			}
+
+			tokenString := parts[1]
+
+			// Validate token
+			claims, err := service.ValidateAccessToken(tokenString)
+			if err != nil {
+				http.Error(w, `{"error":"invalid or expired token"}`, http.StatusUnauthorized)
+				return
+			}
+
+			// Get user ID from claims
+			userID, err := GetUserIDFromClaims(claims)
+			if err != nil {
+				http.Error(w, `{"error":"invalid token claims"}`, http.StatusUnauthorized)
+				return
+			}
+
+			// Get user from database
+			user, err := service.GetCurrentUser(r.Context(), userID)
+			if err != nil {
+				http.Error(w, `{"error":"user not found"}`, http.StatusUnauthorized)
+				return
+			}
+
+			// Add user to context
+			ctx := ContextWithUser(r.Context(), user)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// OptionalAuth middleware adds user to context if token is present, but doesn't require it
+func OptionalAuth(service *Service) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Extract token from Authorization header
+			authHeader := r.Header.Get("Authorization")
+			if authHeader == "" {
+				// No token, continue without user
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Expect "Bearer <token>"
+			parts := strings.SplitN(authHeader, " ", 2)
+			if len(parts) != 2 || strings.ToLower(parts[0]) != "bearer" {
+				// Invalid format, continue without user
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			tokenString := parts[1]
+
+			// Validate token
+			claims, err := service.ValidateAccessToken(tokenString)
+			if err != nil {
+				// Invalid token, continue without user
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Get user ID from claims
+			userID, err := GetUserIDFromClaims(claims)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Get user from database
+			user, err := service.GetCurrentUser(r.Context(), userID)
+			if err != nil {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Add user to context
+			ctx := ContextWithUser(r.Context(), user)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// ValidateCSRF middleware validates the CSRF token for state-changing requests
+func ValidateCSRF(service *Service) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Only validate for state-changing methods
+			if r.Method == http.MethodGet || r.Method == http.MethodHead || r.Method == http.MethodOptions {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// Get CSRF token from header
+			csrfToken := r.Header.Get("X-CSRF-Token")
+			if csrfToken == "" {
+				http.Error(w, `{"error":"missing CSRF token"}`, http.StatusForbidden)
+				return
+			}
+
+			// Validate token
+			if !service.ValidateCSRFToken(csrfToken) {
+				http.Error(w, `{"error":"invalid CSRF token"}`, http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/backend/internal/auth/repository.go
+++ b/backend/internal/auth/repository.go
@@ -1,0 +1,309 @@
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Repository handles database operations for auth
+type Repository struct {
+	db *sql.DB
+}
+
+// NewRepository creates a new auth repository
+func NewRepository(db *sql.DB) *Repository {
+	return &Repository{db: db}
+}
+
+// CreateGuestUser creates a new guest user
+func (r *Repository) CreateGuestUser(ctx context.Context, params *CreateGuestUserParams) (*User, error) {
+	user := &User{
+		ID:        uuid.New(),
+		Name:      params.Name,
+		IsGuest:   true,
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	query := `
+		INSERT INTO users (id, name, is_guest, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`
+
+	_, err := r.db.ExecContext(ctx, query,
+		user.ID, user.Name, user.IsGuest, user.CreatedAt, user.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create guest user: %w", err)
+	}
+
+	return user, nil
+}
+
+// CreateOrUpdateOAuthUser creates a new user or updates an existing one via OAuth
+func (r *Repository) CreateOrUpdateOAuthUser(ctx context.Context, params *CreateOAuthUserParams) (*User, error) {
+	user := &User{
+		ID:        uuid.New(),
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	// Use UPSERT to handle both new users and returning users
+	query := `
+		INSERT INTO users (id, email, google_id, name, avatar_url, is_guest, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, false, $6, $7)
+		ON CONFLICT (google_id) DO UPDATE SET
+			email = EXCLUDED.email,
+			name = EXCLUDED.name,
+			avatar_url = EXCLUDED.avatar_url,
+			is_guest = false,
+			updated_at = EXCLUDED.updated_at
+		RETURNING id, email, google_id, name, avatar_url, is_guest, created_at, updated_at
+	`
+
+	var avatarURL sql.NullString
+	if params.AvatarURL != "" {
+		avatarURL.String = params.AvatarURL
+		avatarURL.Valid = true
+	}
+
+	var email, googleID, avatar sql.NullString
+	err := r.db.QueryRowContext(ctx, query,
+		user.ID, params.Email, params.GoogleID, params.Name, avatarURL, user.CreatedAt, user.UpdatedAt,
+	).Scan(&user.ID, &email, &googleID, &user.Name, &avatar, &user.IsGuest, &user.CreatedAt, &user.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create/update OAuth user: %w", err)
+	}
+
+	if email.Valid {
+		user.Email = &email.String
+	}
+	if googleID.Valid {
+		user.GoogleID = &googleID.String
+	}
+	if avatar.Valid {
+		user.AvatarURL = &avatar.String
+	}
+
+	return user, nil
+}
+
+// GetUserByID retrieves a user by ID
+func (r *Repository) GetUserByID(ctx context.Context, id uuid.UUID) (*User, error) {
+	query := `
+		SELECT id, email, google_id, name, avatar_url, is_guest, created_at, updated_at
+		FROM users
+		WHERE id = $1
+	`
+
+	user := &User{}
+	var email, googleID, avatarURL sql.NullString
+	err := r.db.QueryRowContext(ctx, query, id).Scan(
+		&user.ID, &email, &googleID, &user.Name, &avatarURL, &user.IsGuest, &user.CreatedAt, &user.UpdatedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("user not found")
+		}
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+
+	if email.Valid {
+		user.Email = &email.String
+	}
+	if googleID.Valid {
+		user.GoogleID = &googleID.String
+	}
+	if avatarURL.Valid {
+		user.AvatarURL = &avatarURL.String
+	}
+
+	return user, nil
+}
+
+// GetUserByGoogleID retrieves a user by Google ID
+func (r *Repository) GetUserByGoogleID(ctx context.Context, googleID string) (*User, error) {
+	query := `
+		SELECT id, email, google_id, name, avatar_url, is_guest, created_at, updated_at
+		FROM users
+		WHERE google_id = $1
+	`
+
+	user := &User{}
+	var email, gID, avatarURL sql.NullString
+	err := r.db.QueryRowContext(ctx, query, googleID).Scan(
+		&user.ID, &email, &gID, &user.Name, &avatarURL, &user.IsGuest, &user.CreatedAt, &user.UpdatedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil // Not found is not an error for this query
+		}
+		return nil, fmt.Errorf("failed to get user by google ID: %w", err)
+	}
+
+	if email.Valid {
+		user.Email = &email.String
+	}
+	if gID.Valid {
+		user.GoogleID = &gID.String
+	}
+	if avatarURL.Valid {
+		user.AvatarURL = &avatarURL.String
+	}
+
+	return user, nil
+}
+
+// MergeGuestToOAuth upgrades a guest user to an OAuth user
+func (r *Repository) MergeGuestToOAuth(ctx context.Context, guestID uuid.UUID, params *CreateOAuthUserParams) (*User, error) {
+	query := `
+		UPDATE users SET
+			email = $2,
+			google_id = $3,
+			name = $4,
+			avatar_url = $5,
+			is_guest = false,
+			updated_at = $6
+		WHERE id = $1
+		RETURNING id, email, google_id, name, avatar_url, is_guest, created_at, updated_at
+	`
+
+	var avatarURL sql.NullString
+	if params.AvatarURL != "" {
+		avatarURL.String = params.AvatarURL
+		avatarURL.Valid = true
+	}
+
+	user := &User{}
+	var email, googleID, avatar sql.NullString
+	err := r.db.QueryRowContext(ctx, query,
+		guestID, params.Email, params.GoogleID, params.Name, avatarURL, time.Now(),
+	).Scan(&user.ID, &email, &googleID, &user.Name, &avatar, &user.IsGuest, &user.CreatedAt, &user.UpdatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge guest to OAuth: %w", err)
+	}
+
+	if email.Valid {
+		user.Email = &email.String
+	}
+	if googleID.Valid {
+		user.GoogleID = &googleID.String
+	}
+	if avatar.Valid {
+		user.AvatarURL = &avatar.String
+	}
+
+	return user, nil
+}
+
+// DeleteUser deletes a user
+func (r *Repository) DeleteUser(ctx context.Context, id uuid.UUID) error {
+	query := `DELETE FROM users WHERE id = $1`
+
+	result, err := r.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("failed to delete user: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("user not found")
+	}
+
+	return nil
+}
+
+// hashToken creates a SHA-256 hash of a token
+func hashToken(token string) string {
+	hash := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hash[:])
+}
+
+// StoreRefreshToken stores a refresh token in the database
+func (r *Repository) StoreRefreshToken(ctx context.Context, token string, userID uuid.UUID, expiresAt time.Time) error {
+	query := `
+		INSERT INTO refresh_tokens (token_hash, user_id, expires_at, created_at)
+		VALUES ($1, $2, $3, $4)
+	`
+
+	tokenHash := hashToken(token)
+	_, err := r.db.ExecContext(ctx, query, tokenHash, userID, expiresAt, time.Now())
+	if err != nil {
+		return fmt.Errorf("failed to store refresh token: %w", err)
+	}
+
+	return nil
+}
+
+// GetRefreshToken retrieves a refresh token and its associated user
+func (r *Repository) GetRefreshToken(ctx context.Context, token string) (*RefreshToken, error) {
+	query := `
+		SELECT token_hash, user_id, expires_at, created_at
+		FROM refresh_tokens
+		WHERE token_hash = $1
+	`
+
+	tokenHash := hashToken(token)
+	rt := &RefreshToken{}
+	err := r.db.QueryRowContext(ctx, query, tokenHash).Scan(
+		&rt.TokenHash, &rt.UserID, &rt.ExpiresAt, &rt.CreatedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("refresh token not found")
+		}
+		return nil, fmt.Errorf("failed to get refresh token: %w", err)
+	}
+
+	return rt, nil
+}
+
+// DeleteRefreshToken deletes a refresh token
+func (r *Repository) DeleteRefreshToken(ctx context.Context, token string) error {
+	query := `DELETE FROM refresh_tokens WHERE token_hash = $1`
+
+	tokenHash := hashToken(token)
+	_, err := r.db.ExecContext(ctx, query, tokenHash)
+	if err != nil {
+		return fmt.Errorf("failed to delete refresh token: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteUserRefreshTokens deletes all refresh tokens for a user
+func (r *Repository) DeleteUserRefreshTokens(ctx context.Context, userID uuid.UUID) error {
+	query := `DELETE FROM refresh_tokens WHERE user_id = $1`
+
+	_, err := r.db.ExecContext(ctx, query, userID)
+	if err != nil {
+		return fmt.Errorf("failed to delete user refresh tokens: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteExpiredRefreshTokens deletes all expired refresh tokens
+func (r *Repository) DeleteExpiredRefreshTokens(ctx context.Context) (int64, error) {
+	query := `DELETE FROM refresh_tokens WHERE expires_at < NOW()`
+
+	result, err := r.db.ExecContext(ctx, query)
+	if err != nil {
+		return 0, fmt.Errorf("failed to delete expired refresh tokens: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	return rows, nil
+}

--- a/backend/internal/auth/service.go
+++ b/backend/internal/auth/service.go
@@ -1,0 +1,240 @@
+package auth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Service orchestrates authentication operations
+type Service struct {
+	repo        *Repository
+	jwtManager  *JWTManager
+	csrfManager *CSRFManager
+	googleOAuth *GoogleOAuth
+}
+
+// NewService creates a new auth service
+func NewService(repo *Repository, jwtManager *JWTManager, csrfManager *CSRFManager, googleOAuth *GoogleOAuth) *Service {
+	return &Service{
+		repo:        repo,
+		jwtManager:  jwtManager,
+		csrfManager: csrfManager,
+		googleOAuth: googleOAuth,
+	}
+}
+
+// CreateGuestUser creates a new guest user and returns auth tokens
+func (s *Service) CreateGuestUser(ctx context.Context) (*AuthResponse, string, error) {
+	// Generate a guest name
+	guestName := generateGuestName()
+
+	user, err := s.repo.CreateGuestUser(ctx, &CreateGuestUserParams{
+		Name: guestName,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create guest user: %w", err)
+	}
+
+	// Generate tokens
+	accessToken, expiresAt, err := s.jwtManager.GenerateAccessToken(user)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate access token: %w", err)
+	}
+
+	refreshToken, err := GenerateRefreshToken()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate refresh token: %w", err)
+	}
+
+	// Store refresh token
+	refreshExpiresAt := time.Now().Add(RefreshTokenDuration)
+	if err := s.repo.StoreRefreshToken(ctx, refreshToken, user.ID, refreshExpiresAt); err != nil {
+		return nil, "", fmt.Errorf("failed to store refresh token: %w", err)
+	}
+
+	return &AuthResponse{
+		User:      user,
+		Token:     accessToken,
+		ExpiresAt: expiresAt,
+	}, refreshToken, nil
+}
+
+// GetGoogleAuthURL returns the Google OAuth URL
+func (s *Service) GetGoogleAuthURL(guestUserID *uuid.UUID) string {
+	// Encode guest user ID in state for merge after OAuth
+	state := generateState()
+	if guestUserID != nil {
+		state = guestUserID.String() + ":" + state
+	}
+	return s.googleOAuth.GetAuthURL(state)
+}
+
+// HandleGoogleCallback processes the Google OAuth callback
+func (s *Service) HandleGoogleCallback(ctx context.Context, code string, state string) (*AuthResponse, string, error) {
+	// Exchange code for tokens
+	oauthToken, err := s.googleOAuth.ExchangeCode(ctx, code)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to exchange code: %w", err)
+	}
+
+	// Get user info from Google
+	googleUser, err := s.googleOAuth.GetUserInfo(ctx, oauthToken)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get user info: %w", err)
+	}
+
+	// Parse guest user ID from state (if present)
+	var guestUserID *uuid.UUID
+	if len(state) > 37 && state[36] == ':' {
+		if id, err := uuid.Parse(state[:36]); err == nil {
+			guestUserID = &id
+		}
+	}
+
+	var user *User
+
+	// Check if user already exists with this Google ID
+	existingUser, err := s.repo.GetUserByGoogleID(ctx, googleUser.ID)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to check existing user: %w", err)
+	}
+
+	if existingUser != nil {
+		// User exists, update info if needed
+		user = existingUser
+	} else if guestUserID != nil {
+		// Merge guest user to OAuth user
+		user, err = s.repo.MergeGuestToOAuth(ctx, *guestUserID, googleUser.ToCreateOAuthUserParams())
+		if err != nil {
+			// If merge fails (guest doesn't exist), create new user
+			user, err = s.repo.CreateOrUpdateOAuthUser(ctx, googleUser.ToCreateOAuthUserParams())
+			if err != nil {
+				return nil, "", fmt.Errorf("failed to create OAuth user: %w", err)
+			}
+		}
+	} else {
+		// Create new OAuth user
+		user, err = s.repo.CreateOrUpdateOAuthUser(ctx, googleUser.ToCreateOAuthUserParams())
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create OAuth user: %w", err)
+		}
+	}
+
+	// Generate tokens
+	accessToken, expiresAt, err := s.jwtManager.GenerateAccessToken(user)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate access token: %w", err)
+	}
+
+	refreshToken, err := GenerateRefreshToken()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate refresh token: %w", err)
+	}
+
+	// Store refresh token
+	refreshExpiresAt := time.Now().Add(RefreshTokenDuration)
+	if err := s.repo.StoreRefreshToken(ctx, refreshToken, user.ID, refreshExpiresAt); err != nil {
+		return nil, "", fmt.Errorf("failed to store refresh token: %w", err)
+	}
+
+	// If there was a guest user and we merged or created a different user,
+	// delete the old guest user's refresh tokens
+	if guestUserID != nil && user.ID != *guestUserID {
+		_ = s.repo.DeleteUserRefreshTokens(ctx, *guestUserID)
+	}
+
+	return &AuthResponse{
+		User:      user,
+		Token:     accessToken,
+		ExpiresAt: expiresAt,
+	}, refreshToken, nil
+}
+
+// RefreshAccessToken refreshes the access token using a refresh token
+func (s *Service) RefreshAccessToken(ctx context.Context, refreshTokenStr string) (*AuthResponse, string, error) {
+	// Validate refresh token
+	storedToken, err := s.repo.GetRefreshToken(ctx, refreshTokenStr)
+	if err != nil {
+		return nil, "", fmt.Errorf("invalid refresh token: %w", err)
+	}
+
+	// Check expiration
+	if storedToken.ExpiresAt.Before(time.Now()) {
+		_ = s.repo.DeleteRefreshToken(ctx, refreshTokenStr)
+		return nil, "", fmt.Errorf("refresh token expired")
+	}
+
+	// Get user
+	user, err := s.repo.GetUserByID(ctx, storedToken.UserID)
+	if err != nil {
+		return nil, "", fmt.Errorf("user not found: %w", err)
+	}
+
+	// Generate new access token
+	accessToken, expiresAt, err := s.jwtManager.GenerateAccessToken(user)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate access token: %w", err)
+	}
+
+	// Rotate refresh token
+	_ = s.repo.DeleteRefreshToken(ctx, refreshTokenStr)
+	newRefreshToken, err := GenerateRefreshToken()
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to generate new refresh token: %w", err)
+	}
+
+	refreshExpiresAt := time.Now().Add(RefreshTokenDuration)
+	if err := s.repo.StoreRefreshToken(ctx, newRefreshToken, user.ID, refreshExpiresAt); err != nil {
+		return nil, "", fmt.Errorf("failed to store refresh token: %w", err)
+	}
+
+	return &AuthResponse{
+		User:      user,
+		Token:     accessToken,
+		ExpiresAt: expiresAt,
+	}, newRefreshToken, nil
+}
+
+// Logout invalidates all refresh tokens for a user
+func (s *Service) Logout(ctx context.Context, userID uuid.UUID) error {
+	return s.repo.DeleteUserRefreshTokens(ctx, userID)
+}
+
+// GetCurrentUser retrieves the current user from a user ID
+func (s *Service) GetCurrentUser(ctx context.Context, userID uuid.UUID) (*User, error) {
+	return s.repo.GetUserByID(ctx, userID)
+}
+
+// ValidateAccessToken validates an access token and returns claims
+func (s *Service) ValidateAccessToken(tokenString string) (*JWTClaims, error) {
+	return s.jwtManager.ValidateAccessToken(tokenString)
+}
+
+// GenerateCSRFToken generates a new CSRF token
+func (s *Service) GenerateCSRFToken() (string, error) {
+	return s.csrfManager.GenerateToken()
+}
+
+// ValidateCSRFToken validates a CSRF token
+func (s *Service) ValidateCSRFToken(token string) bool {
+	return s.csrfManager.ValidateToken(token)
+}
+
+// generateGuestName generates a random guest name
+func generateGuestName() string {
+	bytes := make([]byte, 4)
+	rand.Read(bytes)
+	return fmt.Sprintf("Guest-%s", base64.URLEncoding.EncodeToString(bytes)[:6])
+}
+
+// generateState generates a random state string for OAuth
+func generateState() string {
+	bytes := make([]byte, 16)
+	rand.Read(bytes)
+	return base64.URLEncoding.EncodeToString(bytes)
+}

--- a/backend/internal/auth/user.go
+++ b/backend/internal/auth/user.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// User represents an authenticated user
+type User struct {
+	ID        uuid.UUID  `json:"id"`
+	Email     *string    `json:"email,omitempty"`
+	GoogleID  *string    `json:"-"`
+	Name      string     `json:"name"`
+	AvatarURL *string    `json:"avatarUrl,omitempty"`
+	IsGuest   bool       `json:"isGuest"`
+	CreatedAt time.Time  `json:"createdAt"`
+	UpdatedAt time.Time  `json:"updatedAt"`
+}
+
+// CreateGuestUserParams contains parameters for creating a guest user
+type CreateGuestUserParams struct {
+	Name string
+}
+
+// CreateOAuthUserParams contains parameters for creating/updating an OAuth user
+type CreateOAuthUserParams struct {
+	Email     string
+	GoogleID  string
+	Name      string
+	AvatarURL string
+}
+
+// RefreshToken represents a refresh token stored in the database
+type RefreshToken struct {
+	TokenHash string
+	UserID    uuid.UUID
+	ExpiresAt time.Time
+	CreatedAt time.Time
+}
+
+// TokenPair represents an access token and refresh token pair
+type TokenPair struct {
+	AccessToken  string    `json:"accessToken"`
+	RefreshToken string    `json:"-"` // Not exposed in JSON, sent via cookie
+	ExpiresAt    time.Time `json:"expiresAt"`
+}
+
+// AuthResponse is the response returned after successful authentication
+type AuthResponse struct {
+	User      *User     `json:"user"`
+	Token     string    `json:"accessToken"`
+	ExpiresAt time.Time `json:"expiresAt"`
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strconv"
 )
 
 const (
@@ -10,6 +11,9 @@ const (
 
 	// ChunkSize is the number of tokens per chunk file
 	ChunkSize = 5000
+
+	// DefaultGuestDocTTLDays is the default TTL for guest documents
+	DefaultGuestDocTTLDays = 30
 )
 
 // Config holds the application configuration
@@ -17,14 +21,39 @@ type Config struct {
 	Port        string
 	DatabaseURL string
 	StoragePath string
+
+	// Auth configuration
+	JWTSecret          string
+	GoogleClientID     string
+	GoogleClientSecret string
+	GoogleRedirectURL  string
+	CSRFSecret         string
+	FrontendURL        string
+	GuestDocTTLDays    int
+	SecureCookie       bool
 }
 
 // Load reads configuration from environment variables
 func Load() *Config {
+	guestTTL, _ := strconv.Atoi(getEnv("GUEST_DOC_TTL_DAYS", "30"))
+	if guestTTL <= 0 {
+		guestTTL = DefaultGuestDocTTLDays
+	}
+
+	secureCookie := getEnv("SECURE_COOKIE", "false") == "true"
+
 	return &Config{
-		Port:        getEnv("PORT", "8080"),
-		DatabaseURL: getEnv("DATABASE_URL", "postgres://speedreader:speedreader@localhost:5432/speedreader?sslmode=disable"),
-		StoragePath: getEnv("STORAGE_PATH", "./data"),
+		Port:               getEnv("PORT", "8080"),
+		DatabaseURL:        getEnv("DATABASE_URL", "postgres://speedreader:speedreader@localhost:5432/speedreader?sslmode=disable"),
+		StoragePath:        getEnv("STORAGE_PATH", "./data"),
+		JWTSecret:          getEnv("JWT_SECRET", "dev-jwt-secret-change-in-production"),
+		GoogleClientID:     getEnv("GOOGLE_CLIENT_ID", ""),
+		GoogleClientSecret: getEnv("GOOGLE_CLIENT_SECRET", ""),
+		GoogleRedirectURL:  getEnv("GOOGLE_REDIRECT_URL", "http://localhost:8080/api/auth/google/callback"),
+		CSRFSecret:         getEnv("CSRF_SECRET", "dev-csrf-secret-change-in-production"),
+		FrontendURL:        getEnv("FRONTEND_URL", "http://localhost:5173"),
+		GuestDocTTLDays:    guestTTL,
+		SecureCookie:       secureCookie,
 	}
 }
 

--- a/backend/internal/documents/repository.go
+++ b/backend/internal/documents/repository.go
@@ -19,18 +19,31 @@ const (
 	StatusError      DocumentStatus = "error"
 )
 
+// Visibility represents document visibility
+type Visibility string
+
+const (
+	VisibilityPrivate Visibility = "private"
+	VisibilityPublic  Visibility = "public"
+)
+
 // Document represents a stored document
 type Document struct {
 	ID         uuid.UUID      `json:"id"`
+	UserID     *uuid.UUID     `json:"userId,omitempty"`
 	Title      string         `json:"title"`
 	Status     DocumentStatus `json:"status"`
 	TokenCount int            `json:"tokenCount"`
 	ChunkCount int            `json:"chunkCount"`
+	Visibility Visibility     `json:"visibility"`
+	ShareToken *uuid.UUID     `json:"shareToken,omitempty"`
+	ExpiresAt  *time.Time     `json:"expiresAt,omitempty"`
 	CreatedAt  time.Time      `json:"createdAt"`
 }
 
 // ReadingState represents the user's reading progress
 type ReadingState struct {
+	UserID     uuid.UUID `json:"userId"`
 	DocID      uuid.UUID `json:"docId"`
 	TokenIndex int       `json:"tokenIndex"`
 	WPM        int       `json:"wpm"`
@@ -48,22 +61,32 @@ func NewRepository(db *sql.DB) *Repository {
 	return &Repository{db: db}
 }
 
+// CreateParams contains parameters for creating a document
+type CreateParams struct {
+	Title     string
+	UserID    uuid.UUID
+	ExpiresAt *time.Time
+}
+
 // Create inserts a new document
-func (r *Repository) Create(ctx context.Context, title string) (*Document, error) {
+func (r *Repository) Create(ctx context.Context, params *CreateParams) (*Document, error) {
 	doc := &Document{
-		ID:        uuid.New(),
-		Title:     title,
-		Status:    StatusPending,
-		CreatedAt: time.Now(),
+		ID:         uuid.New(),
+		UserID:     &params.UserID,
+		Title:      params.Title,
+		Status:     StatusPending,
+		Visibility: VisibilityPrivate,
+		ExpiresAt:  params.ExpiresAt,
+		CreatedAt:  time.Now(),
 	}
 
 	query := `
-		INSERT INTO documents (id, title, status, token_count, chunk_count, created_at)
-		VALUES ($1, $2, $3, $4, $5, $6)
+		INSERT INTO documents (id, user_id, title, status, token_count, chunk_count, visibility, expires_at, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
 
 	_, err := r.db.ExecContext(ctx, query,
-		doc.ID, doc.Title, doc.Status, doc.TokenCount, doc.ChunkCount, doc.CreatedAt)
+		doc.ID, doc.UserID, doc.Title, doc.Status, doc.TokenCount, doc.ChunkCount, doc.Visibility, doc.ExpiresAt, doc.CreatedAt)
 	if err != nil {
 		return nil, fmt.Errorf("failed to insert document: %w", err)
 	}
@@ -74,19 +97,33 @@ func (r *Repository) Create(ctx context.Context, title string) (*Document, error
 // GetByID retrieves a document by ID
 func (r *Repository) GetByID(ctx context.Context, id uuid.UUID) (*Document, error) {
 	query := `
-		SELECT id, title, status, token_count, chunk_count, created_at
+		SELECT id, user_id, title, status, token_count, chunk_count, visibility, share_token, expires_at, created_at
 		FROM documents
 		WHERE id = $1
 	`
 
 	doc := &Document{}
+	var userID, shareToken sql.NullString
+	var expiresAt sql.NullTime
 	err := r.db.QueryRowContext(ctx, query, id).Scan(
-		&doc.ID, &doc.Title, &doc.Status, &doc.TokenCount, &doc.ChunkCount, &doc.CreatedAt)
+		&doc.ID, &userID, &doc.Title, &doc.Status, &doc.TokenCount, &doc.ChunkCount, &doc.Visibility, &shareToken, &expiresAt, &doc.CreatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, fmt.Errorf("document not found")
 		}
 		return nil, fmt.Errorf("failed to get document: %w", err)
+	}
+
+	if userID.Valid {
+		uid, _ := uuid.Parse(userID.String)
+		doc.UserID = &uid
+	}
+	if shareToken.Valid {
+		st, _ := uuid.Parse(shareToken.String)
+		doc.ShareToken = &st
+	}
+	if expiresAt.Valid {
+		doc.ExpiresAt = &expiresAt.Time
 	}
 
 	return doc, nil
@@ -116,21 +153,22 @@ func (r *Repository) UpdateStatus(ctx context.Context, id uuid.UUID, status Docu
 	return nil
 }
 
-// GetReadingState retrieves the reading state for a document
-func (r *Repository) GetReadingState(ctx context.Context, docID uuid.UUID) (*ReadingState, error) {
+// GetReadingState retrieves the reading state for a document and user
+func (r *Repository) GetReadingState(ctx context.Context, userID, docID uuid.UUID) (*ReadingState, error) {
 	query := `
-		SELECT doc_id, token_index, wpm, chunk_size, updated_at
+		SELECT user_id, doc_id, token_index, wpm, chunk_size, updated_at
 		FROM reading_state
-		WHERE doc_id = $1
+		WHERE user_id = $1 AND doc_id = $2
 	`
 
 	state := &ReadingState{}
-	err := r.db.QueryRowContext(ctx, query, docID).Scan(
-		&state.DocID, &state.TokenIndex, &state.WPM, &state.ChunkSize, &state.UpdatedAt)
+	err := r.db.QueryRowContext(ctx, query, userID, docID).Scan(
+		&state.UserID, &state.DocID, &state.TokenIndex, &state.WPM, &state.ChunkSize, &state.UpdatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			// Return default state if not found
 			return &ReadingState{
+				UserID:     userID,
 				DocID:      docID,
 				TokenIndex: 0,
 				WPM:        300,
@@ -147,9 +185,9 @@ func (r *Repository) GetReadingState(ctx context.Context, docID uuid.UUID) (*Rea
 // UpsertReadingState creates or updates reading state
 func (r *Repository) UpsertReadingState(ctx context.Context, state *ReadingState) error {
 	query := `
-		INSERT INTO reading_state (doc_id, token_index, wpm, chunk_size, updated_at)
-		VALUES ($1, $2, $3, $4, $5)
-		ON CONFLICT (doc_id) DO UPDATE SET
+		INSERT INTO reading_state (user_id, doc_id, token_index, wpm, chunk_size, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (user_id, doc_id) DO UPDATE SET
 			token_index = EXCLUDED.token_index,
 			wpm = EXCLUDED.wpm,
 			chunk_size = EXCLUDED.chunk_size,
@@ -158,7 +196,7 @@ func (r *Repository) UpsertReadingState(ctx context.Context, state *ReadingState
 
 	state.UpdatedAt = time.Now()
 	_, err := r.db.ExecContext(ctx, query,
-		state.DocID, state.TokenIndex, state.WPM, state.ChunkSize, state.UpdatedAt)
+		state.UserID, state.DocID, state.TokenIndex, state.WPM, state.ChunkSize, state.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("failed to upsert reading state: %w", err)
 	}
@@ -166,11 +204,11 @@ func (r *Repository) UpsertReadingState(ctx context.Context, state *ReadingState
 	return nil
 }
 
-// Delete removes a document and its reading state
-func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
-	query := `DELETE FROM documents WHERE id = $1`
+// Delete removes a document owned by a user
+func (r *Repository) Delete(ctx context.Context, id, userID uuid.UUID) error {
+	query := `DELETE FROM documents WHERE id = $1 AND user_id = $2`
 
-	result, err := r.db.ExecContext(ctx, query, id)
+	result, err := r.db.ExecContext(ctx, query, id, userID)
 	if err != nil {
 		return fmt.Errorf("failed to delete document: %w", err)
 	}
@@ -180,7 +218,7 @@ func (r *Repository) Delete(ctx context.Context, id uuid.UUID) error {
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
 	if rows == 0 {
-		return fmt.Errorf("document not found")
+		return fmt.Errorf("document not found or not owned by user")
 	}
 
 	return nil
@@ -194,17 +232,18 @@ type DocumentWithProgress struct {
 	UpdatedAt  time.Time `json:"updatedAt"`
 }
 
-// List retrieves all documents with their reading progress
-func (r *Repository) List(ctx context.Context) ([]DocumentWithProgress, error) {
+// List retrieves all documents for a user with their reading progress
+func (r *Repository) List(ctx context.Context, userID uuid.UUID) ([]DocumentWithProgress, error) {
 	query := `
-		SELECT d.id, d.title, d.status, d.token_count, d.chunk_count, d.created_at,
+		SELECT d.id, d.user_id, d.title, d.status, d.token_count, d.chunk_count, d.visibility, d.share_token, d.expires_at, d.created_at,
 			   COALESCE(rs.token_index, 0), COALESCE(rs.wpm, 300), COALESCE(rs.updated_at, d.created_at)
 		FROM documents d
-		LEFT JOIN reading_state rs ON d.id = rs.doc_id
+		LEFT JOIN reading_state rs ON d.id = rs.doc_id AND rs.user_id = $1
+		WHERE d.user_id = $1
 		ORDER BY COALESCE(rs.updated_at, d.created_at) DESC
 	`
 
-	rows, err := r.db.QueryContext(ctx, query)
+	rows, err := r.db.QueryContext(ctx, query, userID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list documents: %w", err)
 	}
@@ -213,12 +252,25 @@ func (r *Repository) List(ctx context.Context) ([]DocumentWithProgress, error) {
 	var docs []DocumentWithProgress
 	for rows.Next() {
 		var doc DocumentWithProgress
+		var docUserID, shareToken sql.NullString
+		var expiresAt sql.NullTime
 		err := rows.Scan(
-			&doc.ID, &doc.Title, &doc.Status, &doc.TokenCount, &doc.ChunkCount, &doc.CreatedAt,
+			&doc.ID, &docUserID, &doc.Title, &doc.Status, &doc.TokenCount, &doc.ChunkCount, &doc.Visibility, &shareToken, &expiresAt, &doc.CreatedAt,
 			&doc.TokenIndex, &doc.WPM, &doc.UpdatedAt,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan document: %w", err)
+		}
+		if docUserID.Valid {
+			uid, _ := uuid.Parse(docUserID.String)
+			doc.UserID = &uid
+		}
+		if shareToken.Valid {
+			st, _ := uuid.Parse(shareToken.String)
+			doc.ShareToken = &st
+		}
+		if expiresAt.Valid {
+			doc.ExpiresAt = &expiresAt.Time
 		}
 		docs = append(docs, doc)
 	}
@@ -230,11 +282,11 @@ func (r *Repository) List(ctx context.Context) ([]DocumentWithProgress, error) {
 	return docs, nil
 }
 
-// UpdateTitle updates only the title of a document
-func (r *Repository) UpdateTitle(ctx context.Context, id uuid.UUID, title string) error {
-	query := `UPDATE documents SET title = $2 WHERE id = $1`
+// UpdateTitle updates only the title of a document owned by a user
+func (r *Repository) UpdateTitle(ctx context.Context, id, userID uuid.UUID, title string) error {
+	query := `UPDATE documents SET title = $2 WHERE id = $1 AND user_id = $3`
 
-	result, err := r.db.ExecContext(ctx, query, id, title)
+	result, err := r.db.ExecContext(ctx, query, id, title, userID)
 	if err != nil {
 		return fmt.Errorf("failed to update title: %w", err)
 	}
@@ -244,8 +296,71 @@ func (r *Repository) UpdateTitle(ctx context.Context, id uuid.UUID, title string
 		return fmt.Errorf("failed to get rows affected: %w", err)
 	}
 	if rows == 0 {
-		return fmt.Errorf("document not found")
+		return fmt.Errorf("document not found or not owned by user")
 	}
 
 	return nil
+}
+
+// TransferOwnership transfers all documents from one user to another (for guest merge)
+func (r *Repository) TransferOwnership(ctx context.Context, fromUserID, toUserID uuid.UUID) error {
+	// Transfer documents
+	docQuery := `UPDATE documents SET user_id = $2, expires_at = NULL WHERE user_id = $1`
+	_, err := r.db.ExecContext(ctx, docQuery, fromUserID, toUserID)
+	if err != nil {
+		return fmt.Errorf("failed to transfer documents: %w", err)
+	}
+
+	// Transfer reading states
+	rsQuery := `UPDATE reading_state SET user_id = $2 WHERE user_id = $1`
+	_, err = r.db.ExecContext(ctx, rsQuery, fromUserID, toUserID)
+	if err != nil {
+		return fmt.Errorf("failed to transfer reading states: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteExpiredGuestDocuments deletes documents that have expired
+func (r *Repository) DeleteExpiredGuestDocuments(ctx context.Context) ([]uuid.UUID, error) {
+	query := `
+		DELETE FROM documents
+		WHERE expires_at < NOW()
+		RETURNING id
+	`
+
+	rows, err := r.db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("failed to delete expired documents: %w", err)
+	}
+	defer rows.Close()
+
+	var deletedIDs []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("failed to scan deleted ID: %w", err)
+		}
+		deletedIDs = append(deletedIDs, id)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating deleted IDs: %w", err)
+	}
+
+	return deletedIDs, nil
+}
+
+// IsOwner checks if a user owns a document
+func (r *Repository) IsOwner(ctx context.Context, docID, userID uuid.UUID) (bool, error) {
+	query := `SELECT 1 FROM documents WHERE id = $1 AND user_id = $2`
+	var exists int
+	err := r.db.QueryRowContext(ctx, query, docID, userID).Scan(&exists)
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("failed to check ownership: %w", err)
+	}
+	return true, nil
 }

--- a/backend/internal/http/middleware.go
+++ b/backend/internal/http/middleware.go
@@ -13,3 +13,25 @@ func MaxBodySize(next http.Handler) http.Handler {
 		next.ServeHTTP(w, r)
 	})
 }
+
+// SecurityHeaders adds security-related HTTP headers
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Prevent MIME type sniffing
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+
+		// Prevent clickjacking
+		w.Header().Set("X-Frame-Options", "DENY")
+
+		// Enable XSS filter in browsers
+		w.Header().Set("X-XSS-Protection", "1; mode=block")
+
+		// Control referrer information
+		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
+
+		// Permissions policy (disable unnecessary browser features)
+		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -4,42 +4,85 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/go-chi/cors"
+	"github.com/mikepersonal/speed-reader/backend/internal/auth"
 	"github.com/mikepersonal/speed-reader/backend/internal/documents"
+	"github.com/mikepersonal/speed-reader/backend/internal/sharing"
 )
 
+// RouterDeps contains dependencies for the router
+type RouterDeps struct {
+	DocService     *documents.Service
+	AuthService    *auth.Service
+	SharingService *sharing.Service
+	FrontendURL    string
+	SecureCookie   bool
+}
+
 // NewRouter creates a new HTTP router with all routes configured
-func NewRouter(docService *documents.Service) *chi.Mux {
+func NewRouter(deps *RouterDeps) *chi.Mux {
 	r := chi.NewRouter()
 
-	// Middleware
+	// Global middleware
 	r.Use(middleware.Logger)
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.RealIP)
+	r.Use(SecurityHeaders)
 	r.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   []string{"http://localhost:5173", "http://localhost:3000"},
+		AllowedOrigins:   []string{"http://localhost:5173", "http://localhost:3000", deps.FrontendURL},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type", "X-CSRF-Token"},
 		ExposedHeaders:   []string{"Link"},
 		AllowCredentials: true,
 		MaxAge:           300,
 	}))
 
 	// Handlers
-	handlers := NewHandlers(docService)
+	docHandlers := NewHandlers(deps.DocService, deps.SharingService)
+	authHandlers := auth.NewHandlers(deps.AuthService, deps.FrontendURL, deps.SecureCookie)
 
 	// API routes
 	r.Route("/api", func(r chi.Router) {
 		r.Use(MaxBodySize)
 
+		// Auth routes (no auth required for most)
+		r.Route("/auth", func(r chi.Router) {
+			r.Post("/guest", authHandlers.CreateGuest)
+			r.Get("/google", authHandlers.GoogleLogin)
+			r.Get("/google/callback", authHandlers.GoogleCallback)
+			r.Post("/refresh", authHandlers.Refresh)
+
+			// These need optional auth to identify user
+			r.Group(func(r chi.Router) {
+				r.Use(auth.OptionalAuth(deps.AuthService))
+				r.Post("/logout", authHandlers.Logout)
+				r.Get("/me", authHandlers.Me)
+			})
+		})
+
+		// Document routes (require auth)
 		r.Route("/documents", func(r chi.Router) {
-			r.Get("/", handlers.ListDocuments)
-			r.Post("/", handlers.CreateDocument)
-			r.Get("/{id}", handlers.GetDocument)
-			r.Put("/{id}", handlers.UpdateDocument)
-			r.Delete("/{id}", handlers.DeleteDocument)
-			r.Get("/{id}/tokens", handlers.GetTokens)
-			r.Get("/{id}/reading-state", handlers.GetReadingState)
-			r.Put("/{id}/reading-state", handlers.UpdateReadingState)
+			r.Use(auth.RequireAuth(deps.AuthService))
+
+			r.Get("/", docHandlers.ListDocuments)
+			r.Post("/", docHandlers.CreateDocument)
+			r.Get("/{id}", docHandlers.GetDocument)
+			r.Put("/{id}", docHandlers.UpdateDocument)
+			r.Delete("/{id}", docHandlers.DeleteDocument)
+			r.Get("/{id}/tokens", docHandlers.GetTokens)
+			r.Get("/{id}/reading-state", docHandlers.GetReadingState)
+			r.Put("/{id}/reading-state", docHandlers.UpdateReadingState)
+
+			// Sharing routes
+			r.Get("/{id}/share", docHandlers.GetShareInfo)
+			r.Post("/{id}/share", docHandlers.GenerateShareToken)
+			r.Delete("/{id}/share", docHandlers.RevokeShareToken)
+			r.Put("/{id}/visibility", docHandlers.SetVisibility)
+		})
+
+		// Shared document route (no auth required)
+		r.Route("/shared", func(r chi.Router) {
+			r.Get("/{token}", docHandlers.GetSharedDocument)
+			r.Get("/{token}/tokens", docHandlers.GetSharedDocumentTokens)
 		})
 	})
 

--- a/backend/internal/sharing/service.go
+++ b/backend/internal/sharing/service.go
@@ -1,0 +1,248 @@
+package sharing
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Visibility represents document visibility
+type Visibility string
+
+const (
+	VisibilityPrivate Visibility = "private"
+	VisibilityPublic  Visibility = "public"
+)
+
+// SharedDocument represents a document accessed via share token
+type SharedDocument struct {
+	ID         uuid.UUID  `json:"id"`
+	Title      string     `json:"title"`
+	TokenCount int        `json:"tokenCount"`
+	ChunkCount int        `json:"chunkCount"`
+	CreatedAt  time.Time  `json:"createdAt"`
+	OwnerName  string     `json:"ownerName"`
+}
+
+// ShareInfo represents sharing information for a document
+type ShareInfo struct {
+	ShareToken *uuid.UUID `json:"shareToken,omitempty"`
+	ShareURL   string     `json:"shareUrl,omitempty"`
+	Visibility Visibility `json:"visibility"`
+}
+
+// Service handles document sharing operations
+type Service struct {
+	db          *sql.DB
+	frontendURL string
+}
+
+// NewService creates a new sharing service
+func NewService(db *sql.DB, frontendURL string) *Service {
+	return &Service{
+		db:          db,
+		frontendURL: frontendURL,
+	}
+}
+
+// GenerateShareToken creates a share token for a document
+func (s *Service) GenerateShareToken(ctx context.Context, docID, userID uuid.UUID) (*ShareInfo, error) {
+	// Verify ownership
+	if !s.isOwner(ctx, docID, userID) {
+		return nil, fmt.Errorf("not authorized to share this document")
+	}
+
+	shareToken := uuid.New()
+
+	query := `
+		UPDATE documents
+		SET share_token = $2
+		WHERE id = $1 AND user_id = $3
+		RETURNING visibility
+	`
+
+	var visibility string
+	err := s.db.QueryRowContext(ctx, query, docID, shareToken, userID).Scan(&visibility)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate share token: %w", err)
+	}
+
+	return &ShareInfo{
+		ShareToken: &shareToken,
+		ShareURL:   s.buildShareURL(shareToken),
+		Visibility: Visibility(visibility),
+	}, nil
+}
+
+// RevokeShareToken removes the share token from a document
+func (s *Service) RevokeShareToken(ctx context.Context, docID, userID uuid.UUID) error {
+	// Verify ownership
+	if !s.isOwner(ctx, docID, userID) {
+		return fmt.Errorf("not authorized to modify this document")
+	}
+
+	query := `
+		UPDATE documents
+		SET share_token = NULL
+		WHERE id = $1 AND user_id = $2
+	`
+
+	result, err := s.db.ExecContext(ctx, query, docID, userID)
+	if err != nil {
+		return fmt.Errorf("failed to revoke share token: %w", err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+	if rows == 0 {
+		return fmt.Errorf("document not found")
+	}
+
+	return nil
+}
+
+// SetVisibility sets the visibility of a document
+func (s *Service) SetVisibility(ctx context.Context, docID, userID uuid.UUID, visibility Visibility) (*ShareInfo, error) {
+	// Verify ownership
+	if !s.isOwner(ctx, docID, userID) {
+		return nil, fmt.Errorf("not authorized to modify this document")
+	}
+
+	query := `
+		UPDATE documents
+		SET visibility = $2
+		WHERE id = $1 AND user_id = $3
+		RETURNING share_token
+	`
+
+	var shareToken sql.NullString
+	err := s.db.QueryRowContext(ctx, query, docID, visibility, userID).Scan(&shareToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set visibility: %w", err)
+	}
+
+	info := &ShareInfo{
+		Visibility: visibility,
+	}
+
+	if shareToken.Valid {
+		token, _ := uuid.Parse(shareToken.String)
+		info.ShareToken = &token
+		info.ShareURL = s.buildShareURL(token)
+	}
+
+	return info, nil
+}
+
+// GetShareInfo retrieves sharing information for a document
+func (s *Service) GetShareInfo(ctx context.Context, docID, userID uuid.UUID) (*ShareInfo, error) {
+	// Verify ownership
+	if !s.isOwner(ctx, docID, userID) {
+		return nil, fmt.Errorf("not authorized to view this document")
+	}
+
+	query := `
+		SELECT share_token, visibility
+		FROM documents
+		WHERE id = $1 AND user_id = $2
+	`
+
+	var shareToken sql.NullString
+	var visibility string
+	err := s.db.QueryRowContext(ctx, query, docID, userID).Scan(&shareToken, &visibility)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("document not found")
+		}
+		return nil, fmt.Errorf("failed to get share info: %w", err)
+	}
+
+	info := &ShareInfo{
+		Visibility: Visibility(visibility),
+	}
+
+	if shareToken.Valid {
+		token, _ := uuid.Parse(shareToken.String)
+		info.ShareToken = &token
+		info.ShareURL = s.buildShareURL(token)
+	}
+
+	return info, nil
+}
+
+// CanAccessDocument checks if a user can read a document
+func (s *Service) CanAccessDocument(ctx context.Context, docID uuid.UUID, userID *uuid.UUID) (bool, error) {
+	query := `
+		SELECT user_id, visibility
+		FROM documents
+		WHERE id = $1
+	`
+
+	var ownerID sql.NullString
+	var visibility string
+	err := s.db.QueryRowContext(ctx, query, docID).Scan(&ownerID, &visibility)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check access: %w", err)
+	}
+
+	// Public documents are accessible to everyone
+	if visibility == string(VisibilityPublic) {
+		return true, nil
+	}
+
+	// For private documents, check ownership
+	if userID == nil {
+		return false, nil
+	}
+
+	if ownerID.Valid {
+		owner, _ := uuid.Parse(ownerID.String)
+		return owner == *userID, nil
+	}
+
+	return false, nil
+}
+
+// GetDocumentByShareToken retrieves a document by share token (read-only access)
+func (s *Service) GetDocumentByShareToken(ctx context.Context, shareToken uuid.UUID) (*SharedDocument, error) {
+	query := `
+		SELECT d.id, d.title, d.token_count, d.chunk_count, d.created_at, u.name
+		FROM documents d
+		JOIN users u ON d.user_id = u.id
+		WHERE d.share_token = $1 AND d.status = 'ready'
+	`
+
+	doc := &SharedDocument{}
+	err := s.db.QueryRowContext(ctx, query, shareToken).Scan(
+		&doc.ID, &doc.Title, &doc.TokenCount, &doc.ChunkCount, &doc.CreatedAt, &doc.OwnerName,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("shared document not found")
+		}
+		return nil, fmt.Errorf("failed to get shared document: %w", err)
+	}
+
+	return doc, nil
+}
+
+// isOwner checks if a user owns a document
+func (s *Service) isOwner(ctx context.Context, docID, userID uuid.UUID) bool {
+	query := `SELECT 1 FROM documents WHERE id = $1 AND user_id = $2`
+	var exists int
+	err := s.db.QueryRowContext(ctx, query, docID, userID).Scan(&exists)
+	return err == nil
+}
+
+// buildShareURL builds the frontend share URL
+func (s *Service) buildShareURL(shareToken uuid.UUID) string {
+	return fmt.Sprintf("%s/shared/%s", s.frontendURL, shareToken.String())
+}

--- a/backend/migrations/003_create_users.down.sql
+++ b/backend/migrations/003_create_users.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_users_is_guest;
+DROP INDEX IF EXISTS idx_users_google_id;
+DROP INDEX IF EXISTS idx_users_email;
+DROP TABLE IF EXISTS users;

--- a/backend/migrations/003_create_users.up.sql
+++ b/backend/migrations/003_create_users.up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    email TEXT UNIQUE,
+    google_id TEXT UNIQUE,
+    name TEXT NOT NULL,
+    avatar_url TEXT,
+    is_guest BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_users_email ON users(email) WHERE email IS NOT NULL;
+CREATE INDEX idx_users_google_id ON users(google_id) WHERE google_id IS NOT NULL;
+CREATE INDEX idx_users_is_guest ON users(is_guest) WHERE is_guest = true;

--- a/backend/migrations/004_add_auth_to_documents.down.sql
+++ b/backend/migrations/004_add_auth_to_documents.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS idx_documents_expires_at;
+DROP INDEX IF EXISTS idx_documents_share_token;
+DROP INDEX IF EXISTS idx_documents_user_id;
+
+ALTER TABLE documents DROP COLUMN IF EXISTS expires_at;
+ALTER TABLE documents DROP COLUMN IF EXISTS share_token;
+ALTER TABLE documents DROP COLUMN IF EXISTS visibility;
+ALTER TABLE documents DROP COLUMN IF EXISTS user_id;

--- a/backend/migrations/004_add_auth_to_documents.up.sql
+++ b/backend/migrations/004_add_auth_to_documents.up.sql
@@ -1,0 +1,13 @@
+-- Add user ownership and sharing to documents
+ALTER TABLE documents ADD COLUMN user_id UUID REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE documents ADD COLUMN visibility TEXT NOT NULL DEFAULT 'private' CHECK (visibility IN ('private', 'public'));
+ALTER TABLE documents ADD COLUMN share_token UUID UNIQUE;
+ALTER TABLE documents ADD COLUMN expires_at TIMESTAMP WITH TIME ZONE;
+
+-- Create indexes for auth queries
+CREATE INDEX idx_documents_user_id ON documents(user_id);
+CREATE INDEX idx_documents_share_token ON documents(share_token) WHERE share_token IS NOT NULL;
+CREATE INDEX idx_documents_expires_at ON documents(expires_at) WHERE expires_at IS NOT NULL;
+
+-- Note: user_id is nullable initially to allow for migration of existing data
+-- In practice, all new documents will have user_id set

--- a/backend/migrations/005_update_reading_state.down.sql
+++ b/backend/migrations/005_update_reading_state.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_reading_state_user_id;
+
+ALTER TABLE reading_state DROP CONSTRAINT reading_state_pkey;
+ALTER TABLE reading_state DROP COLUMN IF EXISTS user_id;
+ALTER TABLE reading_state ADD PRIMARY KEY (doc_id);

--- a/backend/migrations/005_update_reading_state.up.sql
+++ b/backend/migrations/005_update_reading_state.up.sql
@@ -1,0 +1,12 @@
+-- Add user_id to reading_state and change primary key to composite
+-- First, drop the existing primary key
+ALTER TABLE reading_state DROP CONSTRAINT reading_state_pkey;
+
+-- Add user_id column
+ALTER TABLE reading_state ADD COLUMN user_id UUID REFERENCES users(id) ON DELETE CASCADE;
+
+-- Create new composite primary key
+ALTER TABLE reading_state ADD PRIMARY KEY (user_id, doc_id);
+
+-- Add index for user queries
+CREATE INDEX idx_reading_state_user_id ON reading_state(user_id);

--- a/backend/migrations/006_create_refresh_tokens.down.sql
+++ b/backend/migrations/006_create_refresh_tokens.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_refresh_tokens_expires_at;
+DROP INDEX IF EXISTS idx_refresh_tokens_user_id;
+DROP TABLE IF EXISTS refresh_tokens;

--- a/backend/migrations/006_create_refresh_tokens.up.sql
+++ b/backend/migrations/006_create_refresh_tokens.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE refresh_tokens (
+    token_hash TEXT PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,11 @@
-import { lazy, Suspense } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { lazy, Suspense, useEffect } from 'react';
+import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
+import { AuthProvider, useAuthContext } from './contexts/AuthContext';
 import { PasteInputView } from './views';
 
 const ReaderView = lazy(() => import('./views/ReaderView'));
 const LibraryView = lazy(() => import('./views/LibraryView'));
+const SharedDocView = lazy(() => import('./views/SharedDocView'));
 
 function LoadingFallback() {
   return (
@@ -13,17 +15,35 @@ function LoadingFallback() {
   );
 }
 
+function AuthCallback() {
+  const navigate = useNavigate();
+  const { isLoading, isAuthenticated } = useAuthContext();
+
+  useEffect(() => {
+    // Once auth is no longer loading, redirect to home
+    if (!isLoading) {
+      navigate('/', { replace: true });
+    }
+  }, [isLoading, isAuthenticated, navigate]);
+
+  return <LoadingFallback />;
+}
+
 function App() {
   return (
-    <BrowserRouter>
-      <Suspense fallback={<LoadingFallback />}>
-        <Routes>
-          <Route path="/" element={<PasteInputView />} />
-          <Route path="/library" element={<LibraryView />} />
-          <Route path="/read/:id" element={<ReaderView />} />
-        </Routes>
-      </Suspense>
-    </BrowserRouter>
+    <AuthProvider>
+      <BrowserRouter>
+        <Suspense fallback={<LoadingFallback />}>
+          <Routes>
+            <Route path="/" element={<PasteInputView />} />
+            <Route path="/library" element={<LibraryView />} />
+            <Route path="/read/:id" element={<ReaderView />} />
+            <Route path="/shared/:token" element={<SharedDocView />} />
+            <Route path="/auth/callback" element={<AuthCallback />} />
+          </Routes>
+        </Suspense>
+      </BrowserRouter>
+    </AuthProvider>
   );
 }
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,161 @@
+import type { AuthResponse, User, ShareInfo, SharedDocument } from '../types/user';
+
+const API_BASE = '/api/auth';
+
+export async function createGuestUser(): Promise<AuthResponse> {
+  const response = await fetch(`${API_BASE}/guest`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to create guest user' }));
+    throw new Error(error.error);
+  }
+
+  return response.json();
+}
+
+export async function refreshToken(): Promise<AuthResponse> {
+  const response = await fetch(`${API_BASE}/refresh`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to refresh token' }));
+    throw new Error(error.error);
+  }
+
+  return response.json();
+}
+
+export async function logout(): Promise<void> {
+  await fetch(`${API_BASE}/logout`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+}
+
+export async function getCurrentUser(accessToken: string): Promise<User> {
+  const response = await fetch(`${API_BASE}/me`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to get user' }));
+    throw new Error(error.error);
+  }
+
+  return response.json();
+}
+
+export function getGoogleAuthUrl(): string {
+  return `${API_BASE}/google`;
+}
+
+// Sharing API
+const SHARE_BASE = '/api/documents';
+
+export async function getShareInfo(
+  docId: string,
+  accessToken: string
+): Promise<ShareInfo> {
+  const response = await fetch(`${SHARE_BASE}/${docId}/share`, {
+    method: 'GET',
+    credentials: 'include',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to get share info' }));
+    throw new Error(error.error);
+  }
+
+  return response.json();
+}
+
+export async function generateShareToken(
+  docId: string,
+  accessToken: string
+): Promise<ShareInfo> {
+  const response = await fetch(`${SHARE_BASE}/${docId}/share`, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to generate share token' }));
+    throw new Error(error.error);
+  }
+
+  return response.json();
+}
+
+export async function revokeShareToken(
+  docId: string,
+  accessToken: string
+): Promise<void> {
+  const response = await fetch(`${SHARE_BASE}/${docId}/share`, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to revoke share token' }));
+    throw new Error(error.error);
+  }
+}
+
+export async function setVisibility(
+  docId: string,
+  visibility: 'private' | 'public',
+  accessToken: string
+): Promise<ShareInfo> {
+  const response = await fetch(`${SHARE_BASE}/${docId}/visibility`, {
+    method: 'PUT',
+    credentials: 'include',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ visibility }),
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Failed to set visibility' }));
+    throw new Error(error.error);
+  }
+
+  return response.json();
+}
+
+// Shared document access (no auth required)
+const SHARED_BASE = '/api/shared';
+
+export async function getSharedDocument(shareToken: string): Promise<SharedDocument> {
+  const response = await fetch(`${SHARED_BASE}/${shareToken}`, {
+    method: 'GET',
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ error: 'Shared document not found' }));
+    throw new Error(error.error);
+  }
+
+  return response.json();
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,7 +8,40 @@ export class ApiError extends Error {
   }
 }
 
-async function handleResponse<T>(response: Response): Promise<T> {
+// Token management
+let accessToken: string | null = null;
+let refreshTokenFn: (() => Promise<string | null>) | null = null;
+
+export function setAccessToken(token: string | null) {
+  accessToken = token;
+}
+
+export function setRefreshTokenFn(fn: () => Promise<string | null>) {
+  refreshTokenFn = fn;
+}
+
+async function getAuthHeaders(): Promise<HeadersInit> {
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+  };
+
+  if (accessToken) {
+    headers['Authorization'] = `Bearer ${accessToken}`;
+  }
+
+  return headers;
+}
+
+async function handleResponse<T>(response: Response, retryFn?: () => Promise<T>): Promise<T> {
+  if (response.status === 401 && refreshTokenFn && retryFn) {
+    // Try to refresh the token and retry
+    const newToken = await refreshTokenFn();
+    if (newToken) {
+      accessToken = newToken;
+      return retryFn();
+    }
+  }
+
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: 'Unknown error' }));
     throw new ApiError(error.error || 'Request failed', response.status);
@@ -17,46 +50,61 @@ async function handleResponse<T>(response: Response): Promise<T> {
 }
 
 export async function get<T>(url: string): Promise<T> {
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-  return handleResponse<T>(response);
+  const makeRequest = async (): Promise<T> => {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: await getAuthHeaders(),
+      credentials: 'include',
+    });
+    return handleResponse<T>(response, makeRequest);
+  };
+  return makeRequest();
 }
 
 export async function post<T, B>(url: string, body: B): Promise<T> {
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
-  });
-  return handleResponse<T>(response);
+  const makeRequest = async (): Promise<T> => {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: await getAuthHeaders(),
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+    return handleResponse<T>(response, makeRequest);
+  };
+  return makeRequest();
 }
 
 export async function put<T, B>(url: string, body: B): Promise<T> {
-  const response = await fetch(url, {
-    method: 'PUT',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
-  });
-  return handleResponse<T>(response);
+  const makeRequest = async (): Promise<T> => {
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: await getAuthHeaders(),
+      credentials: 'include',
+      body: JSON.stringify(body),
+    });
+    return handleResponse<T>(response, makeRequest);
+  };
+  return makeRequest();
 }
 
 export async function del(url: string): Promise<void> {
-  const response = await fetch(url, {
-    method: 'DELETE',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ error: 'Unknown error' }));
-    throw new ApiError(error.error || 'Request failed', response.status);
-  }
+  const makeRequest = async (): Promise<void> => {
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: await getAuthHeaders(),
+      credentials: 'include',
+    });
+    if (response.status === 401 && refreshTokenFn) {
+      const newToken = await refreshTokenFn();
+      if (newToken) {
+        accessToken = newToken;
+        return makeRequest();
+      }
+    }
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ error: 'Unknown error' }));
+      throw new ApiError(error.error || 'Request failed', response.status);
+    }
+  };
+  return makeRequest();
 }

--- a/frontend/src/components/ShareModal.tsx
+++ b/frontend/src/components/ShareModal.tsx
@@ -1,0 +1,248 @@
+import { useState, useEffect, useCallback } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { X, Link2, Copy, Check, Globe, Lock, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '../hooks/useAuth';
+import {
+  getShareInfo,
+  generateShareToken,
+  revokeShareToken,
+  setVisibility,
+} from '../api/auth';
+import type { ShareInfo } from '../types/user';
+
+interface ShareModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  documentId: string;
+  documentTitle: string;
+}
+
+export function ShareModal({ isOpen, onClose, documentId, documentTitle }: ShareModalProps) {
+  const { getAccessToken } = useAuth();
+  const [shareInfo, setShareInfo] = useState<ShareInfo | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isCopied, setIsCopied] = useState(false);
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchShareInfo = useCallback(async () => {
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const info = await getShareInfo(documentId, token);
+      setShareInfo(info);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load share info');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [documentId, getAccessToken]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsLoading(true);
+      fetchShareInfo();
+    }
+  }, [isOpen, fetchShareInfo]);
+
+  const handleGenerateLink = async () => {
+    setIsUpdating(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const info = await generateShareToken(documentId, token);
+      setShareInfo(info);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate share link');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleRevokeLink = async () => {
+    setIsUpdating(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      await revokeShareToken(documentId, token);
+      setShareInfo((prev) => prev ? { ...prev, shareToken: undefined, shareUrl: undefined } : null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to revoke share link');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleToggleVisibility = async () => {
+    if (!shareInfo) return;
+    setIsUpdating(true);
+    try {
+      const token = await getAccessToken();
+      if (!token) return;
+      const newVisibility = shareInfo.visibility === 'private' ? 'public' : 'private';
+      const info = await setVisibility(documentId, newVisibility, token);
+      setShareInfo(info);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update visibility');
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const handleCopyLink = async () => {
+    if (!shareInfo?.shareUrl) return;
+    try {
+      await navigator.clipboard.writeText(shareInfo.shareUrl);
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch {
+      setError('Failed to copy link');
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50"
+            onClick={onClose}
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          >
+            <div
+              className="w-full max-w-md bg-bg-elevated border border-border rounded-xl shadow-2xl shadow-black/40"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between p-4 border-b border-border">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-lg bg-amber-400/10 flex items-center justify-center">
+                    <Link2 className="w-5 h-5 text-amber-400" />
+                  </div>
+                  <div>
+                    <h2 className="font-serif font-semibold text-lg text-text-primary">
+                      Share Document
+                    </h2>
+                    <p className="text-sm text-text-secondary truncate max-w-[200px]">
+                      {documentTitle}
+                    </p>
+                  </div>
+                </div>
+                <button
+                  onClick={onClose}
+                  className="p-2 rounded-lg hover:bg-bg-surface transition-colors"
+                >
+                  <X className="w-5 h-5 text-text-tertiary" />
+                </button>
+              </div>
+
+              <div className="p-4 space-y-4">
+                {isLoading ? (
+                  <div className="flex items-center justify-center py-8">
+                    <div className="text-text-tertiary">Loading...</div>
+                  </div>
+                ) : error ? (
+                  <div className="p-3 bg-destructive/10 border border-destructive/30 rounded-lg text-destructive text-sm">
+                    {error}
+                  </div>
+                ) : (
+                  <>
+                    {/* Visibility Toggle */}
+                    <div className="flex items-center justify-between p-3 bg-bg-surface rounded-lg">
+                      <div className="flex items-center gap-3">
+                        {shareInfo?.visibility === 'public' ? (
+                          <Globe className="w-5 h-5 text-amber-400" />
+                        ) : (
+                          <Lock className="w-5 h-5 text-text-tertiary" />
+                        )}
+                        <div>
+                          <div className="text-sm font-medium text-text-primary">
+                            {shareInfo?.visibility === 'public' ? 'Public' : 'Private'}
+                          </div>
+                          <div className="text-xs text-text-secondary">
+                            {shareInfo?.visibility === 'public'
+                              ? 'Anyone with the link can view'
+                              : 'Only you can view'}
+                          </div>
+                        </div>
+                      </div>
+                      <button
+                        onClick={handleToggleVisibility}
+                        disabled={isUpdating}
+                        className="px-3 py-1.5 text-sm rounded-lg bg-bg-elevated hover:bg-bg-base transition-colors disabled:opacity-50"
+                      >
+                        {isUpdating ? '...' : 'Change'}
+                      </button>
+                    </div>
+
+                    {/* Share Link Section */}
+                    <div className="space-y-3">
+                      <div className="text-sm font-medium text-text-primary">
+                        Share Link
+                      </div>
+
+                      {shareInfo?.shareUrl ? (
+                        <div className="space-y-3">
+                          <div className="flex items-center gap-2">
+                            <div className="flex-1 p-3 bg-bg-surface rounded-lg font-mono text-sm text-text-secondary truncate">
+                              {shareInfo.shareUrl}
+                            </div>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={handleCopyLink}
+                              className="shrink-0 gap-2"
+                            >
+                              {isCopied ? (
+                                <>
+                                  <Check className="w-4 h-4 text-green-500" />
+                                  Copied
+                                </>
+                              ) : (
+                                <>
+                                  <Copy className="w-4 h-4" />
+                                  Copy
+                                </>
+                              )}
+                            </Button>
+                          </div>
+                          <button
+                            onClick={handleRevokeLink}
+                            disabled={isUpdating}
+                            className="flex items-center gap-2 text-sm text-text-tertiary hover:text-destructive transition-colors disabled:opacity-50"
+                          >
+                            <Trash2 className="w-4 h-4" />
+                            Revoke link
+                          </button>
+                        </div>
+                      ) : (
+                        <Button
+                          onClick={handleGenerateLink}
+                          disabled={isUpdating}
+                          className="w-full gap-2"
+                        >
+                          <Link2 className="w-4 h-4" />
+                          {isUpdating ? 'Generating...' : 'Generate Share Link'}
+                        </Button>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/UserMenu.tsx
+++ b/frontend/src/components/UserMenu.tsx
@@ -1,0 +1,161 @@
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { User, LogIn, LogOut, ChevronDown } from 'lucide-react';
+import { useAuth } from '../hooks/useAuth';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export function UserMenu() {
+  const { user, isLoading, login, logout } = useAuth();
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (isLoading) {
+    return (
+      <div className="w-8 h-8 rounded-full bg-bg-surface animate-pulse" />
+    );
+  }
+
+  if (!user) {
+    return (
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={login}
+        className="gap-2"
+      >
+        <LogIn className="w-4 h-4" />
+        Sign In
+      </Button>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={cn(
+          "flex items-center gap-2 px-3 py-2 rounded-lg transition-colors",
+          "hover:bg-bg-elevated focus:outline-none focus:ring-2 focus:ring-amber-400/30",
+          isOpen && "bg-bg-elevated"
+        )}
+      >
+        {user.avatarUrl ? (
+          <img
+            src={user.avatarUrl}
+            alt={user.name}
+            className="w-8 h-8 rounded-full ring-2 ring-amber-400/30"
+          />
+        ) : (
+          <div className="w-8 h-8 rounded-full bg-amber-400/20 flex items-center justify-center">
+            <User className="w-4 h-4 text-amber-400" />
+          </div>
+        )}
+        <div className="hidden sm:block text-left">
+          <div className="text-sm font-medium text-text-primary truncate max-w-[120px]">
+            {user.name}
+          </div>
+          {user.isGuest && (
+            <div className="text-xs text-amber-400/80">Guest</div>
+          )}
+        </div>
+        <ChevronDown
+          className={cn(
+            "w-4 h-4 text-text-tertiary transition-transform",
+            isOpen && "rotate-180"
+          )}
+        />
+      </button>
+
+      <AnimatePresence>
+        {isOpen && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="fixed inset-0 z-40"
+              onClick={() => setIsOpen(false)}
+            />
+            <motion.div
+              initial={{ opacity: 0, y: -8, scale: 0.95 }}
+              animate={{ opacity: 1, y: 0, scale: 1 }}
+              exit={{ opacity: 0, y: -8, scale: 0.95 }}
+              transition={{ duration: 0.15 }}
+              className="absolute right-0 top-full mt-2 w-64 z-50 bg-bg-elevated border border-border rounded-lg shadow-xl shadow-black/30 overflow-hidden"
+            >
+              <div className="p-4 border-b border-border">
+                <div className="flex items-center gap-3">
+                  {user.avatarUrl ? (
+                    <img
+                      src={user.avatarUrl}
+                      alt={user.name}
+                      className="w-12 h-12 rounded-full ring-2 ring-amber-400/30"
+                    />
+                  ) : (
+                    <div className="w-12 h-12 rounded-full bg-amber-400/20 flex items-center justify-center">
+                      <User className="w-6 h-6 text-amber-400" />
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-text-primary truncate">
+                      {user.name}
+                    </div>
+                    {user.email && (
+                      <div className="text-sm text-text-secondary truncate">
+                        {user.email}
+                      </div>
+                    )}
+                    {user.isGuest && (
+                      <div className="text-xs text-amber-400 mt-0.5">
+                        Guest Account
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+
+              <div className="p-2">
+                {user.isGuest ? (
+                  <button
+                    onClick={() => {
+                      setIsOpen(false);
+                      login();
+                    }}
+                    className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left hover:bg-bg-surface transition-colors group"
+                  >
+                    <div className="w-8 h-8 rounded-full bg-amber-400/10 flex items-center justify-center group-hover:bg-amber-400/20 transition-colors">
+                      <LogIn className="w-4 h-4 text-amber-400" />
+                    </div>
+                    <div>
+                      <div className="text-sm font-medium text-text-primary">
+                        Sign in with Google
+                      </div>
+                      <div className="text-xs text-text-secondary">
+                        Keep your documents forever
+                      </div>
+                    </div>
+                  </button>
+                ) : (
+                  <button
+                    onClick={async () => {
+                      setIsOpen(false);
+                      await logout();
+                    }}
+                    className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left hover:bg-bg-surface transition-colors group"
+                  >
+                    <div className="w-8 h-8 rounded-full bg-bg-surface flex items-center justify-center group-hover:bg-destructive/10 transition-colors">
+                      <LogOut className="w-4 h-4 text-text-tertiary group-hover:text-destructive transition-colors" />
+                    </div>
+                    <div className="text-sm text-text-primary group-hover:text-destructive transition-colors">
+                      Sign out
+                    </div>
+                  </button>
+                )}
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,237 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from 'react';
+import type { User } from '../types/user';
+import {
+  createGuestUser,
+  refreshToken as refreshTokenApi,
+  logout as logoutApi,
+  getGoogleAuthUrl,
+} from '../api/auth';
+import { setAccessToken, setRefreshTokenFn } from '../api/client';
+
+interface AuthState {
+  user: User | null;
+  accessToken: string | null;
+  isLoading: boolean;
+  isAuthenticated: boolean;
+}
+
+interface AuthContextValue extends AuthState {
+  login: () => void;
+  logout: () => Promise<void>;
+  refreshAuth: () => Promise<boolean>;
+  getAccessToken: () => Promise<string | null>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export function AuthProvider({ children }: AuthProviderProps) {
+  const [state, setState] = useState<AuthState>({
+    user: null,
+    accessToken: null,
+    isLoading: true,
+    isAuthenticated: false,
+  });
+
+  const [tokenExpiresAt, setTokenExpiresAt] = useState<Date | null>(null);
+
+  // Sync access token with API client
+  useEffect(() => {
+    setAccessToken(state.accessToken);
+  }, [state.accessToken]);
+
+  // Set up refresh token function in API client
+  useEffect(() => {
+    setRefreshTokenFn(async () => {
+      try {
+        const response = await refreshTokenApi();
+        setState({
+          user: response.user,
+          accessToken: response.accessToken,
+          isLoading: false,
+          isAuthenticated: true,
+        });
+        setTokenExpiresAt(new Date(response.expiresAt));
+        return response.accessToken;
+      } catch {
+        return null;
+      }
+    });
+  }, []);
+
+  // Initialize auth on mount
+  useEffect(() => {
+    // Check if this is an OAuth callback - if so, let handleOAuthCallback handle it
+    const hash = window.location.hash;
+    if (hash.startsWith('#token=')) {
+      const token = hash.substring(7);
+      // Clear the hash from URL
+      window.history.replaceState(null, '', window.location.pathname);
+      // Handle OAuth callback
+      handleOAuthCallback(token);
+    } else {
+      // Normal initialization - try to refresh or create guest
+      initializeAuth();
+    }
+  }, []);
+
+  const initializeAuth = async () => {
+    try {
+      // Try to refresh existing session
+      const response = await refreshTokenApi();
+      setState({
+        user: response.user,
+        accessToken: response.accessToken,
+        isLoading: false,
+        isAuthenticated: true,
+      });
+      setTokenExpiresAt(new Date(response.expiresAt));
+    } catch {
+      // No valid session, create guest user
+      try {
+        const response = await createGuestUser();
+        setState({
+          user: response.user,
+          accessToken: response.accessToken,
+          isLoading: false,
+          isAuthenticated: true,
+        });
+        setTokenExpiresAt(new Date(response.expiresAt));
+      } catch (guestError) {
+        console.error('Failed to create guest user:', guestError);
+        setState({
+          user: null,
+          accessToken: null,
+          isLoading: false,
+          isAuthenticated: false,
+        });
+      }
+    }
+  };
+
+  const handleOAuthCallback = async (_token: string) => {
+    // The token from OAuth callback - we use refresh to get the full user info
+    setState(prev => ({ ...prev, isLoading: true }));
+    try {
+      const response = await refreshTokenApi();
+      setState({
+        user: response.user,
+        accessToken: response.accessToken,
+        isLoading: false,
+        isAuthenticated: true,
+      });
+      setTokenExpiresAt(new Date(response.expiresAt));
+    } catch (error) {
+      console.error('OAuth callback failed:', error);
+      setState(prev => ({ ...prev, isLoading: false }));
+    }
+  };
+
+  const refreshAuth = useCallback(async (): Promise<boolean> => {
+    try {
+      const response = await refreshTokenApi();
+      setState({
+        user: response.user,
+        accessToken: response.accessToken,
+        isLoading: false,
+        isAuthenticated: true,
+      });
+      setTokenExpiresAt(new Date(response.expiresAt));
+      return true;
+    } catch {
+      // If refresh fails, create a new guest user
+      try {
+        const response = await createGuestUser();
+        setState({
+          user: response.user,
+          accessToken: response.accessToken,
+          isLoading: false,
+          isAuthenticated: true,
+        });
+        setTokenExpiresAt(new Date(response.expiresAt));
+        return true;
+      } catch {
+        setState({
+          user: null,
+          accessToken: null,
+          isLoading: false,
+          isAuthenticated: false,
+        });
+        return false;
+      }
+    }
+  }, []);
+
+  const getAccessToken = useCallback(async (): Promise<string | null> => {
+    // Check if token is expired or about to expire (within 1 minute)
+    if (tokenExpiresAt) {
+      const now = new Date();
+      const expiresIn = tokenExpiresAt.getTime() - now.getTime();
+      if (expiresIn < 60000) {
+        // Token expired or expiring soon, refresh
+        const success = await refreshAuth();
+        if (!success) return null;
+      }
+    }
+    return state.accessToken;
+  }, [state.accessToken, tokenExpiresAt, refreshAuth]);
+
+  const login = useCallback(() => {
+    // Redirect to Google OAuth
+    window.location.href = getGoogleAuthUrl();
+  }, []);
+
+  const logout = useCallback(async () => {
+    try {
+      await logoutApi();
+    } catch (error) {
+      console.error('Logout error:', error);
+    }
+    // Create a new guest user after logout
+    try {
+      const response = await createGuestUser();
+      setState({
+        user: response.user,
+        accessToken: response.accessToken,
+        isLoading: false,
+        isAuthenticated: true,
+      });
+      setTokenExpiresAt(new Date(response.expiresAt));
+    } catch {
+      setState({
+        user: null,
+        accessToken: null,
+        isLoading: false,
+        isAuthenticated: false,
+      });
+    }
+  }, []);
+
+  const value: AuthContextValue = {
+    ...state,
+    login,
+    logout,
+    refreshAuth,
+    getAccessToken,
+  };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuthContext(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuthContext must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,20 @@
+import { useAuthContext } from '../contexts/AuthContext';
+
+export function useAuth() {
+  return useAuthContext();
+}
+
+export function useUser() {
+  const { user } = useAuthContext();
+  return user;
+}
+
+export function useIsAuthenticated() {
+  const { isAuthenticated, isLoading } = useAuthContext();
+  return { isAuthenticated, isLoading };
+}
+
+export function useAccessToken() {
+  const { getAccessToken } = useAuthContext();
+  return getAccessToken;
+}

--- a/frontend/src/types/document.ts
+++ b/frontend/src/types/document.ts
@@ -1,11 +1,16 @@
 export type DocumentStatus = 'pending' | 'processing' | 'ready' | 'error';
+export type DocumentVisibility = 'private' | 'public';
 
 export interface Document {
   id: string;
+  userId?: string;
   title: string;
   status: DocumentStatus;
   tokenCount: number;
   chunkCount: number;
+  visibility: DocumentVisibility;
+  shareToken?: string;
+  expiresAt?: string;
   createdAt: string;
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './token';
 export * from './document';
+export * from './user';

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,0 +1,30 @@
+export interface User {
+  id: string;
+  email?: string;
+  name: string;
+  avatarUrl?: string;
+  isGuest: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AuthResponse {
+  user: User;
+  accessToken: string;
+  expiresAt: string;
+}
+
+export interface ShareInfo {
+  shareToken?: string;
+  shareUrl?: string;
+  visibility: 'private' | 'public';
+}
+
+export interface SharedDocument {
+  id: string;
+  title: string;
+  tokenCount: number;
+  chunkCount: number;
+  createdAt: string;
+  ownerName: string;
+}

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -4,6 +4,7 @@ import { motion } from 'motion/react';
 import { Plus, Library, FileText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { DocumentCard } from '../components/DocumentCard';
+import { UserMenu } from '../components/UserMenu';
 import { listDocuments, updateDocument, deleteDocument } from '../api';
 import type { DocumentWithProgress } from '../types';
 
@@ -66,6 +67,7 @@ function LibraryView() {
             initial={{ opacity: 0, x: 12 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.4 }}
+            className="flex items-center gap-4"
           >
             <Button
               onClick={() => navigate('/')}
@@ -74,6 +76,7 @@ function LibraryView() {
               <Plus className="w-4 h-4" />
               New Document
             </Button>
+            <UserMenu />
           </motion.div>
         </div>
       </header>

--- a/frontend/src/views/PasteInputView.tsx
+++ b/frontend/src/views/PasteInputView.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { UserMenu } from '../components/UserMenu';
 import { cn } from '@/lib/utils';
 
 const MAX_SIZE = 1024 * 1024; // 1MB
@@ -41,9 +42,15 @@ export function PasteInputView() {
   }, [title, content, isOverLimit, isSubmitting, navigate]);
 
   return (
-    <div className="min-h-screen bg-warm-gradient bg-grain flex items-center justify-center p-4 md:p-8">
-      <div className="max-w-2xl w-full relative z-10">
-        <Card className="border border-border bg-bg-elevated/95 backdrop-blur-sm shadow-2xl shadow-black/30">
+    <div className="min-h-screen bg-warm-gradient bg-grain flex flex-col">
+      {/* Header with UserMenu */}
+      <header className="fixed top-0 right-0 z-20 p-4">
+        <UserMenu />
+      </header>
+
+      <div className="flex-1 flex items-center justify-center p-4 md:p-8">
+        <div className="max-w-2xl w-full relative z-10">
+          <Card className="border border-border bg-bg-elevated/95 backdrop-blur-sm shadow-2xl shadow-black/30">
           <CardHeader className="text-center pb-6">
             <motion.div
               initial={{ opacity: 0, y: 12 }}
@@ -143,6 +150,7 @@ export function PasteInputView() {
             </motion.form>
           </CardContent>
         </Card>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/views/ReaderView.tsx
+++ b/frontend/src/views/ReaderView.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, Share2 } from 'lucide-react';
 import { RSVPDisplay, ControlBar, ProgressBar } from '../components';
+import { UserMenu } from '../components/UserMenu';
+import { ShareModal } from '../components/ShareModal';
 import { RSVPEngine, type RSVPConfig } from '../engine/RSVPEngine';
 import { getDocument, getTokens, getReadingState, updateReadingState } from '../api';
 import type { Document, Token } from '../types';
@@ -23,6 +25,7 @@ function ReaderView() {
   const [config, setConfig] = useState<RSVPConfig>({ wpm: 300, chunkSize: 1 });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isShareModalOpen, setIsShareModalOpen] = useState(false);
 
   const engineRef = useRef<RSVPEngine | null>(null);
   const lastSaveRef = useRef<number>(0);
@@ -245,7 +248,26 @@ function ReaderView() {
         <h1 className="flex-1 text-lg md:text-xl font-semibold text-text-primary truncate">
           {document?.title}
         </h1>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setIsShareModalOpen(true)}
+          className="gap-2 text-text-secondary hover:text-amber-400 hover:bg-bg-surface"
+        >
+          <Share2 className="w-4 h-4" />
+          <span className="hidden sm:inline">Share</span>
+        </Button>
+        <UserMenu />
       </header>
+
+      {document && (
+        <ShareModal
+          isOpen={isShareModalOpen}
+          onClose={() => setIsShareModalOpen(false)}
+          documentId={document.id}
+          documentTitle={document.title}
+        />
+      )}
 
       <main className="flex-1 flex items-center justify-center p-4 md:p-8">
         <RSVPDisplay tokens={currentTokens} />

--- a/frontend/src/views/SharedDocView.tsx
+++ b/frontend/src/views/SharedDocView.tsx
@@ -1,0 +1,253 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { motion } from 'motion/react';
+import { Play, Pause, SkipBack, SkipForward, ChevronLeft, User } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Slider } from '@/components/ui/slider';
+import { RSVPDisplay } from '../components/RSVPDisplay';
+import { getSharedDocument } from '../api/auth';
+import { get } from '../api/client';
+import { RSVPEngine } from '../engine/RSVPEngine';
+import type { SharedDocument } from '../types/user';
+import type { Token, Chunk } from '../types';
+
+const TOKENS_PER_CHUNK = 5000;
+
+function SharedDocView() {
+  const { token: shareToken } = useParams<{ token: string }>();
+  const navigate = useNavigate();
+  const [document, setDocument] = useState<SharedDocument | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // RSVP state
+  const [currentTokens, setCurrentTokens] = useState<Token[]>([]);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [wpm, setWpm] = useState(300);
+  const [position, setPosition] = useState(0);
+
+  const engineRef = useRef<RSVPEngine | null>(null);
+  const loadedChunksRef = useRef<Set<number>>(new Set());
+
+  // Fetch document metadata
+  useEffect(() => {
+    if (!shareToken) return;
+
+    const fetchDocument = async () => {
+      try {
+        const doc = await getSharedDocument(shareToken);
+        setDocument(doc);
+        setError(null);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load shared document');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchDocument();
+  }, [shareToken]);
+
+  // Load chunk
+  const loadChunk = useCallback(async (chunkIndex: number) => {
+    if (!shareToken || !document || loadedChunksRef.current.has(chunkIndex)) return;
+
+    try {
+      const chunk = await get<Chunk>(`/api/shared/${shareToken}/tokens?chunk=${chunkIndex}`);
+      loadedChunksRef.current.add(chunkIndex);
+
+      if (engineRef.current) {
+        engineRef.current.setTokens(
+          chunk.tokens,
+          chunkIndex,
+          document.tokenCount,
+          TOKENS_PER_CHUNK
+        );
+      }
+    } catch (err) {
+      console.error(`Failed to load chunk ${chunkIndex}:`, err);
+    }
+  }, [shareToken, document]);
+
+  // Initialize engine
+  useEffect(() => {
+    const engine = new RSVPEngine({
+      onTokenChange: (tokens) => setCurrentTokens(tokens),
+      onStateChange: (playing) => setIsPlaying(playing),
+      onPositionChange: (index) => setPosition(index),
+      onNeedMoreTokens: (chunkIndex) => {
+        if (!loadedChunksRef.current.has(chunkIndex)) {
+          loadChunk(chunkIndex);
+        }
+      },
+    });
+
+    engineRef.current = engine;
+
+    return () => {
+      engine.destroy();
+    };
+  }, [loadChunk]);
+
+  // Load initial tokens when document is available
+  useEffect(() => {
+    if (document && shareToken && engineRef.current) {
+      loadChunk(0);
+    }
+  }, [document, shareToken, loadChunk]);
+
+  // Update WPM
+  useEffect(() => {
+    if (engineRef.current) {
+      engineRef.current.setConfig({ wpm });
+    }
+  }, [wpm]);
+
+  const handlePlayPause = () => {
+    engineRef.current?.toggle();
+  };
+
+  const handleSeek = (offset: number) => {
+    if (!engineRef.current) return;
+    engineRef.current.setPosition(position + offset);
+  };
+
+  const totalTokens = document?.tokenCount || 0;
+  const progress = totalTokens > 0 ? (position / totalTokens) * 100 : 0;
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-vignette flex items-center justify-center">
+        <div className="text-text-secondary font-rsvp text-xl italic">Loading...</div>
+      </div>
+    );
+  }
+
+  if (error || !document) {
+    return (
+      <div className="min-h-screen bg-vignette flex flex-col items-center justify-center p-4">
+        <div className="text-center max-w-md">
+          <div className="text-6xl mb-6">🔗</div>
+          <h1 className="text-2xl font-serif font-semibold text-text-primary mb-3">
+            Document Not Found
+          </h1>
+          <p className="text-text-secondary mb-6">
+            {error || 'This shared link may have expired or been revoked.'}
+          </p>
+          <Button onClick={() => navigate('/')}>
+            Go to Speed Reader
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-vignette flex flex-col">
+      {/* Header */}
+      <header className="sticky top-0 z-10 bg-bg-base/80 backdrop-blur-md border-b border-border">
+        <div className="max-w-4xl mx-auto px-4 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate('/')}
+              className="gap-2"
+            >
+              <ChevronLeft className="w-4 h-4" />
+              <span className="hidden sm:inline">Speed Reader</span>
+            </Button>
+          </div>
+          <div className="flex items-center gap-2 text-sm text-text-secondary">
+            <User className="w-4 h-4" />
+            <span>Shared by {document.ownerName}</span>
+          </div>
+        </div>
+      </header>
+
+      {/* Title */}
+      <div className="max-w-4xl mx-auto px-4 py-6 text-center">
+        <motion.h1
+          initial={{ opacity: 0, y: -10 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="text-2xl md:text-3xl font-serif font-semibold text-text-primary"
+        >
+          {document.title}
+        </motion.h1>
+      </div>
+
+      {/* RSVP Display */}
+      <div className="flex-1 flex items-center justify-center px-4">
+        <RSVPDisplay tokens={currentTokens} />
+      </div>
+
+      {/* Progress Bar */}
+      <div className="max-w-4xl mx-auto w-full px-4 py-2">
+        <div className="h-1 bg-bg-surface rounded-full overflow-hidden">
+          <motion.div
+            className="h-full bg-amber-400"
+            style={{ width: `${progress}%` }}
+            transition={{ duration: 0.1 }}
+          />
+        </div>
+        <div className="flex justify-between mt-1 text-xs text-text-tertiary font-counter">
+          <span>{position.toLocaleString()}</span>
+          <span>{totalTokens.toLocaleString()} words</span>
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="max-w-4xl mx-auto w-full px-4 py-6">
+        <div className="flex items-center justify-center gap-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => handleSeek(-10)}
+            disabled={currentTokens.length === 0}
+          >
+            <SkipBack className="w-5 h-5" />
+          </Button>
+
+          <motion.button
+            whileTap={{ scale: 0.95 }}
+            onClick={handlePlayPause}
+            disabled={currentTokens.length === 0}
+            className="w-14 h-14 rounded-full bg-amber-400 text-bg-deep flex items-center justify-center shadow-lg shadow-amber-400/20 hover:bg-amber-300 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isPlaying ? (
+              <Pause className="w-6 h-6" />
+            ) : (
+              <Play className="w-6 h-6 ml-1" />
+            )}
+          </motion.button>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => handleSeek(10)}
+            disabled={currentTokens.length === 0}
+          >
+            <SkipForward className="w-5 h-5" />
+          </Button>
+        </div>
+
+        {/* WPM Slider */}
+        <div className="mt-6 flex items-center justify-center gap-4">
+          <span className="text-sm text-text-tertiary w-12">WPM</span>
+          <Slider
+            value={[wpm]}
+            onValueChange={([v]) => setWpm(v)}
+            min={100}
+            max={1000}
+            step={25}
+            className="w-48"
+          />
+          <span className="text-sm font-counter text-amber-400 w-12">{wpm}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export { SharedDocView };
+export default SharedDocView;


### PR DESCRIPTION
## Summary
- Implements guest-first authentication flow where users start as guests and can upgrade via Google OAuth
- Adds JWT-based access tokens (15min) with HttpOnly refresh token cookies (7 days) and CSRF protection
- Creates user-scoped document access with automatic ownership transfer when guest accounts merge with OAuth accounts
- Adds document sharing via unique share tokens with public/private visibility toggle
- Includes UserMenu component, ShareModal for share link management, and SharedDocView for read-only shared access
- Creates background cleanup job for expired guest documents (30 day TTL)

## New Files
**Backend (19 files):**
- `internal/auth/` - Full auth package (user, repository, jwt, google, csrf, service, middleware, handlers, context)
- `internal/sharing/service.go` - Document sharing service
- `cmd/cleanup/main.go` - Cleanup job for expired guest documents
- `migrations/003-006` - Database migrations for users, auth fields, reading state, refresh tokens

**Frontend (7 files):**
- `contexts/AuthContext.tsx` - Auth state management with auto-refresh
- `hooks/useAuth.ts` - Auth hooks
- `api/auth.ts` - Auth API client
- `types/user.ts` - User types
- `components/UserMenu.tsx` - User menu with sign in/out
- `components/ShareModal.tsx` - Share link management modal
- `views/SharedDocView.tsx` - Read-only shared document viewer

## Test plan
- [ ] Reset database with `make db-reset` to apply new migrations
- [ ] Configure Google OAuth credentials in `backend/.env`
- [ ] Start app with `make dev`
- [ ] Verify guest user auto-created on first visit
- [ ] Create a document as guest
- [ ] Sign in with Google and verify documents transferred
- [ ] Test share link generation and access in incognito window
- [ ] Test token refresh by waiting 15+ minutes
- [ ] Verify logout creates new guest session

🤖 Generated with [Claude Code](https://claude.com/claude-code)