### PR TITLE
fix: migrate guest documents to new account on OAuth sign up

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -54,8 +54,12 @@ export async function getCurrentUser(accessToken: string): Promise<User> {
   return response.json();
 }
 
-export function getGoogleAuthUrl(): string {
-  return `${API_BASE}/google`;
+export function getGoogleAuthUrl(guestId?: string): string {
+  const base = `${API_BASE}/google`;
+  if (guestId) {
+    return `${base}?guest_id=${guestId}`;
+  }
+  return base;
 }
 
 // Sharing API

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -187,9 +187,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   }, [state.accessToken, tokenExpiresAt, refreshAuth]);
 
   const login = useCallback(() => {
-    // Redirect to Google OAuth
-    window.location.href = getGoogleAuthUrl();
-  }, []);
+    // Pass guest user ID so documents can be migrated on sign up
+    const guestId = state.user?.isGuest ? state.user.id : undefined;
+    window.location.href = getGoogleAuthUrl(guestId);
+  }, [state.user]);
 
   const logout = useCallback(async () => {
     try {


### PR DESCRIPTION
## Summary
- Pass guest user ID via query parameter when initiating Google OAuth flow
- Backend reads guest ID from query param instead of relying on context (which was empty due to browser navigation)
- Enables document migration when a guest user creates a new account via OAuth

## Problem
When a guest user created documents and then signed up with Google OAuth, their documents were lost. The root cause was that browser navigation to `/api/auth/google` doesn't include Authorization headers, so the backend couldn't identify the guest user from context.

## Solution
Frontend now appends `?guest_id=<uuid>` to the OAuth URL when the current user is a guest. The backend parses this query parameter and encodes it in the OAuth state, which triggers the existing `MergeGuestToOAuth` logic after successful authentication.

## Test plan
- [ ] Start dev environment with `make dev`
- [ ] Create a document as a guest user
- [ ] Click "Sign in with Google" and complete OAuth with a **new** Google account
- [ ] Verify the guest document appears in your library (migration worked)
- [ ] Sign out (creates new guest)
- [ ] Create another document as the new guest
- [ ] Sign in with the **same** Google account from before
- [ ] Verify only the original document is there (new guest doc NOT transferred)

🤖 Generated with [Claude Code](https://claude.com/claude-code)