### PR TITLE
feat: add tiered file limits and optional document titles

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -6,8 +6,15 @@ import (
 )
 
 const (
-	// MaxPasteSize is the maximum allowed paste size (1MB)
-	MaxPasteSize = 1 * 1024 * 1024
+	// MaxGuestPasteSize is the maximum allowed paste size for guest users (1MB)
+	MaxGuestPasteSize = 1 * 1024 * 1024
+
+	// MaxAuthPasteSize is the maximum allowed paste size for authenticated users (10MB)
+	MaxAuthPasteSize = 10 * 1024 * 1024
+
+	// MaxPasteSize is kept for backward compatibility (same as guest limit)
+	// Deprecated: Use MaxGuestPasteSize or MaxAuthPasteSize instead
+	MaxPasteSize = MaxGuestPasteSize
 
 	// ChunkSize is the number of tokens per chunk file
 	ChunkSize = 5000

--- a/backend/internal/documents/namegen.go
+++ b/backend/internal/documents/namegen.go
@@ -1,0 +1,45 @@
+package documents
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+var (
+	// Adjectives themed around reading, wisdom, and nocturnal atmosphere
+	adjectives = []string{
+		// Nocturnal/atmospheric
+		"Midnight", "Twilight", "Starlit", "Moonlit", "Shadowy",
+		"Velvet", "Dusky", "Amber", "Crimson", "Golden",
+		// Intellectual/scholarly
+		"Curious", "Wandering", "Ancient", "Mystic", "Wise",
+		"Noble", "Clever", "Swift", "Silent", "Whispering",
+		// Nature-inspired
+		"Emerald", "Silver", "Sapphire", "Copper", "Ivory",
+		"Gentle", "Radiant", "Hidden", "Forgotten", "Eternal",
+	}
+
+	// Nouns themed around readers, creatures, and literary concepts
+	nouns = []string{
+		// Creatures (nocturnal/wise)
+		"Owl", "Raven", "Fox", "Wolf", "Moth",
+		"Hare", "Badger", "Hedgehog", "Finch", "Wren",
+		// Scholarly figures
+		"Scholar", "Scribe", "Sage", "Bard", "Poet",
+		"Reader", "Dreamer", "Wanderer", "Seeker", "Keeper",
+		// Literary objects
+		"Quill", "Scroll", "Tome", "Chronicle", "Sonnet",
+		"Ballad", "Fable", "Verse", "Chapter", "Inkwell",
+	}
+
+	rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+)
+
+// GenerateRandomTitle creates a fun random document name
+// using the pattern "Adjective Noun" (e.g., "Midnight Scholar", "Curious Owl")
+func GenerateRandomTitle() string {
+	adj := adjectives[rng.Intn(len(adjectives))]
+	noun := nouns[rng.Intn(len(nouns))]
+	return fmt.Sprintf("%s %s", adj, noun)
+}

--- a/backend/internal/documents/namegen_test.go
+++ b/backend/internal/documents/namegen_test.go
@@ -1,0 +1,45 @@
+package documents
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateRandomTitle(t *testing.T) {
+	// Generate multiple titles to check the format
+	for i := 0; i < 10; i++ {
+		title := GenerateRandomTitle()
+
+		// Should have exactly two words (Adjective Noun)
+		words := strings.Split(title, " ")
+		if len(words) != 2 {
+			t.Errorf("Expected 2 words, got %d: %q", len(words), title)
+		}
+
+		// Both words should start with uppercase
+		for _, word := range words {
+			if word == "" {
+				t.Errorf("Empty word in title: %q", title)
+				continue
+			}
+			if word[0] < 'A' || word[0] > 'Z' {
+				t.Errorf("Word should start with uppercase: %q in %q", word, title)
+			}
+		}
+	}
+}
+
+func TestGenerateRandomTitle_Uniqueness(t *testing.T) {
+	// Generate many titles and check they're not all the same
+	titles := make(map[string]bool)
+	for i := 0; i < 50; i++ {
+		title := GenerateRandomTitle()
+		titles[title] = true
+	}
+
+	// With 30 adjectives × 30 nouns = 900 combinations,
+	// generating 50 titles should produce at least a few unique ones
+	if len(titles) < 10 {
+		t.Errorf("Expected at least 10 unique titles, got %d", len(titles))
+	}
+}

--- a/backend/internal/documents/service.go
+++ b/backend/internal/documents/service.go
@@ -3,6 +3,7 @@ package documents
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -34,6 +35,12 @@ func (s *Service) CreateDocument(ctx context.Context, title, content string) (*D
 	user, ok := auth.UserFromContext(ctx)
 	if !ok {
 		return nil, fmt.Errorf("user not found in context")
+	}
+
+	// Generate random title if not provided
+	title = strings.TrimSpace(title)
+	if title == "" {
+		title = GenerateRandomTitle()
 	}
 
 	// Set expiration for guest documents

--- a/backend/internal/http/handlers.go
+++ b/backend/internal/http/handlers.go
@@ -74,11 +74,7 @@ func (h *Handlers) CreateDocument(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Title == "" {
-		writeError(w, http.StatusBadRequest, "title is required")
-		return
-	}
-
+	// Title is optional - service will generate a random name if empty
 	if req.Content == "" {
 		writeError(w, http.StatusBadRequest, "content is required")
 		return

--- a/backend/internal/http/middleware.go
+++ b/backend/internal/http/middleware.go
@@ -3,13 +3,28 @@ package http
 import (
 	"net/http"
 
+	"github.com/mikepersonal/speed-reader/backend/internal/auth"
 	"github.com/mikepersonal/speed-reader/backend/internal/config"
 )
 
-// MaxBodySize limits the request body size
+// MaxBodySize limits the request body size (uses guest limit)
+// Deprecated: Use ContextAwareMaxBodySize for user-specific limits
 func MaxBodySize(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		r.Body = http.MaxBytesReader(w, r.Body, config.MaxPasteSize)
+		next.ServeHTTP(w, r)
+	})
+}
+
+// ContextAwareMaxBodySize limits the request body size based on user type
+// Guest users get 1MB limit, authenticated users get 10MB limit
+func ContextAwareMaxBodySize(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		limit := int64(config.MaxGuestPasteSize)
+		if user, ok := auth.UserFromContext(r.Context()); ok && !user.IsGuest {
+			limit = config.MaxAuthPasteSize
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, limit)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -42,8 +42,6 @@ func NewRouter(deps *RouterDeps) *chi.Mux {
 
 	// API routes
 	r.Route("/api", func(r chi.Router) {
-		r.Use(MaxBodySize)
-
 		// Auth routes (no auth required for most)
 		r.Route("/auth", func(r chi.Router) {
 			r.Post("/guest", authHandlers.CreateGuest)
@@ -62,6 +60,7 @@ func NewRouter(deps *RouterDeps) *chi.Mux {
 		// Document routes (require auth)
 		r.Route("/documents", func(r chi.Router) {
 			r.Use(auth.RequireAuth(deps.AuthService))
+			r.Use(ContextAwareMaxBodySize) // Apply body size limit after auth so we know user type
 
 			r.Get("/", docHandlers.ListDocuments)
 			r.Post("/", docHandlers.CreateDocument)

--- a/frontend/src/types/document.ts
+++ b/frontend/src/types/document.ts
@@ -23,7 +23,7 @@ export interface ReadingState {
 }
 
 export interface CreateDocumentRequest {
-  title: string;
+  title?: string; // Optional - server will generate a fun random name if not provided
   content: string;
 }
 


### PR DESCRIPTION
## Summary
- Increase file size limit to 10MB for authenticated users (guests remain at 1MB)
- Make document title optional - server generates fun random names like "Midnight Scholar" or "Curious Owl"
- Constrain textarea height to prevent viewport overflow

## Changes

### Backend
- Added `MaxGuestPasteSize` (1MB) and `MaxAuthPasteSize` (10MB) constants
- Created `ContextAwareMaxBodySize` middleware that checks user type
- Added random name generator with nocturnal/scholarly themed words
- Removed title validation requirement from handler
- Service generates random title when empty

### Frontend
- Dynamic size limit display based on user type
- Title input now optional with helpful placeholder text
- Textarea constrained to `max-h-[50vh]`

## Test plan
- [ ] Guest user sees 1 MB limit and cannot upload larger files
- [ ] Authenticated user sees 10 MB limit and can upload larger files
- [ ] Creating document without title generates a fun random name
- [ ] Creating document with title uses the provided title
- [ ] Textarea cannot expand beyond viewport height

🤖 Generated with [Claude Code](https://claude.ai/code)