### PR TITLE
feat: add document text editing from Library page

### DIFF
--- a/backend/internal/http/router.go
+++ b/backend/internal/http/router.go
@@ -72,6 +72,7 @@ func NewRouter(deps *RouterDeps) *chi.Mux {
 			r.Put("/{id}", docHandlers.UpdateDocument)
 			r.Delete("/{id}", docHandlers.DeleteDocument)
 			r.Get("/{id}/tokens", docHandlers.GetTokens)
+			r.Get("/{id}/content", docHandlers.GetDocumentContent)
 			r.Get("/{id}/reading-state", docHandlers.GetReadingState)
 			r.Put("/{id}/reading-state", docHandlers.UpdateReadingState)
 

--- a/backend/migrations/007_add_content_to_documents.down.sql
+++ b/backend/migrations/007_add_content_to_documents.down.sql
@@ -1,0 +1,3 @@
+-- Revert content column addition
+DROP INDEX IF EXISTS idx_documents_has_content;
+ALTER TABLE documents DROP COLUMN IF EXISTS content;

--- a/backend/migrations/007_add_content_to_documents.up.sql
+++ b/backend/migrations/007_add_content_to_documents.up.sql
@@ -1,0 +1,6 @@
+-- Add content column to store original document text for editing
+-- Nullable to support existing documents that don't have stored content
+ALTER TABLE documents ADD COLUMN content TEXT;
+
+-- Index to efficiently filter documents with/without content
+CREATE INDEX idx_documents_has_content ON documents ((content IS NOT NULL));

--- a/frontend/src/api/documents.ts
+++ b/frontend/src/api/documents.ts
@@ -7,6 +7,7 @@ import type {
   ReadingState,
   UpdateReadingStateRequest,
   Chunk,
+  GetContentResponse,
 } from '../types';
 
 const API_BASE = '/api/documents';
@@ -47,4 +48,8 @@ export async function updateReadingState(
     `${API_BASE}/${id}/reading-state`,
     request
   );
+}
+
+export async function getDocumentContent(id: string): Promise<GetContentResponse> {
+  return get<GetContentResponse>(`${API_BASE}/${id}/content`);
 }

--- a/frontend/src/components/DocumentCard.tsx
+++ b/frontend/src/components/DocumentCard.tsx
@@ -1,25 +1,21 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { motion, AnimatePresence } from 'motion/react';
-import { Pencil, Trash2, Check, X, BookOpen } from 'lucide-react';
+import { Pencil, Trash2, Check, BookOpen } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import type { DocumentWithProgress } from '../types';
 
 interface DocumentCardProps {
   document: DocumentWithProgress;
-  onRename: (id: string, title: string) => Promise<void>;
+  onEdit: (document: DocumentWithProgress) => void;
   onDelete: (id: string) => Promise<void>;
   animationDelay?: number;
 }
 
-export const DocumentCard = React.memo(function DocumentCard({ document, onRename, onDelete, animationDelay = 0 }: DocumentCardProps) {
+export const DocumentCard = React.memo(function DocumentCard({ document, onEdit, onDelete, animationDelay = 0 }: DocumentCardProps) {
   const navigate = useNavigate();
-  const [isEditing, setIsEditing] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
-  const [editTitle, setEditTitle] = useState(document.title);
   const [isLoading, setIsLoading] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
 
   const progress = document.tokenCount > 0
     ? (document.tokenIndex / document.tokenCount) * 100
@@ -27,44 +23,6 @@ export const DocumentCard = React.memo(function DocumentCard({ document, onRenam
 
   const isCompleted = progress >= 99;
   const hasStarted = document.tokenIndex > 0;
-
-  useEffect(() => {
-    if (isEditing && inputRef.current) {
-      inputRef.current.focus();
-      inputRef.current.select();
-    }
-  }, [isEditing]);
-
-  const handleSaveRename = async () => {
-    if (!editTitle.trim() || editTitle === document.title) {
-      setIsEditing(false);
-      setEditTitle(document.title);
-      return;
-    }
-
-    setIsLoading(true);
-    try {
-      await onRename(document.id, editTitle.trim());
-      setIsEditing(false);
-    } catch {
-      setEditTitle(document.title);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  const handleCancelRename = () => {
-    setEditTitle(document.title);
-    setIsEditing(false);
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      handleSaveRename();
-    } else if (e.key === 'Escape') {
-      handleCancelRename();
-    }
-  };
 
   const handleConfirmDelete = async () => {
     setIsLoading(true);
@@ -133,63 +91,32 @@ export const DocumentCard = React.memo(function DocumentCard({ document, onRenam
             >
               <div className="p-5">
                 <div className="flex items-start justify-between gap-3 mb-4">
-                  {isEditing ? (
-                    <div className="flex-1 flex items-center gap-2">
-                      <Input
-                        ref={inputRef}
-                        value={editTitle}
-                        onChange={(e) => setEditTitle(e.target.value)}
-                        onKeyDown={handleKeyDown}
-                        disabled={isLoading}
-                        className="h-8 text-base"
-                      />
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        onClick={handleSaveRename}
-                        disabled={isLoading}
-                        className="h-8 w-8 text-green-500 hover:text-green-400 hover:bg-green-500/10"
-                      >
-                        <Check className="w-4 h-4" />
-                      </Button>
-                      <Button
-                        size="icon"
-                        variant="ghost"
-                        onClick={handleCancelRename}
-                        disabled={isLoading}
-                        className="h-8 w-8 text-text-tertiary hover:text-text-secondary"
-                      >
-                        <X className="w-4 h-4" />
-                      </Button>
-                    </div>
-                  ) : (
-                    <>
-                      <h3
-                        className="font-serif font-medium text-text-primary text-lg leading-tight line-clamp-2 cursor-pointer hover:text-amber-400 transition-colors"
-                        onClick={() => navigate(`/read/${document.id}`)}
-                      >
-                        {document.title}
-                      </h3>
-                      <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          onClick={() => setIsEditing(true)}
-                          className="h-7 w-7 text-text-tertiary hover:text-amber-400"
-                        >
-                          <Pencil className="w-3.5 h-3.5" />
-                        </Button>
-                        <Button
-                          size="icon"
-                          variant="ghost"
-                          onClick={() => setIsDeleting(true)}
-                          className="h-7 w-7 text-text-tertiary hover:text-destructive"
-                        >
-                          <Trash2 className="w-3.5 h-3.5" />
-                        </Button>
-                      </div>
-                    </>
-                  )}
+                  <h3
+                    className="font-serif font-medium text-text-primary text-lg leading-tight line-clamp-2 cursor-pointer hover:text-amber-400 transition-colors"
+                    onClick={() => navigate(`/read/${document.id}`)}
+                  >
+                    {document.title}
+                  </h3>
+                  <div className="flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => onEdit(document)}
+                      className="h-7 w-7 text-text-tertiary hover:text-amber-400"
+                      title="Edit document"
+                    >
+                      <Pencil className="w-3.5 h-3.5" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      onClick={() => setIsDeleting(true)}
+                      className="h-7 w-7 text-text-tertiary hover:text-destructive"
+                      title="Delete document"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </Button>
+                  </div>
                 </div>
 
                 <div className="flex items-center gap-2 text-xs text-text-tertiary font-counter mb-4">

--- a/frontend/src/components/EditDocumentModal.tsx
+++ b/frontend/src/components/EditDocumentModal.tsx
@@ -1,0 +1,294 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { motion, AnimatePresence } from 'motion/react';
+import { X, FileText, AlertCircle, Save, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { getDocumentContent, updateDocument } from '../api';
+import type { DocumentWithProgress } from '../types';
+
+interface EditDocumentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  document: DocumentWithProgress | null;
+  onUpdate: (updatedDoc: DocumentWithProgress) => void;
+}
+
+export function EditDocumentModal({ isOpen, onClose, document, onUpdate }: EditDocumentModalProps) {
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [originalContent, setOriginalContent] = useState('');
+  const [hasContent, setHasContent] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  const fetchContent = useCallback(async () => {
+    if (!document) return;
+
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await getDocumentContent(document.id);
+      setContent(response.content);
+      setOriginalContent(response.content);
+      setHasContent(response.hasContent);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load document content');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [document]);
+
+  useEffect(() => {
+    if (isOpen && document) {
+      setTitle(document.title);
+      fetchContent();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen, document?.id]);
+
+  useEffect(() => {
+    if (isOpen && !isLoading && hasContent && titleInputRef.current) {
+      titleInputRef.current.focus();
+      titleInputRef.current.select();
+    }
+  }, [isOpen, isLoading, hasContent]);
+
+  const handleSave = async () => {
+    if (!document) return;
+
+    if (!title.trim()) {
+      setError('Title is required');
+      return;
+    }
+
+    if (!content.trim()) {
+      setError('Content is required');
+      return;
+    }
+
+    setIsSaving(true);
+    setError(null);
+
+    try {
+      // Determine if we need to update content or just title
+      const contentChanged = content !== originalContent;
+      const titleChanged = title !== document.title;
+
+      if (!contentChanged && !titleChanged) {
+        onClose();
+        return;
+      }
+
+      const updatedDoc = await updateDocument(document.id, {
+        title: title.trim(),
+        ...(contentChanged ? { content } : {}),
+      });
+
+      // Merge updated doc with progress info
+      onUpdate({
+        ...updatedDoc,
+        tokenIndex: contentChanged ? 0 : document.tokenIndex, // Reset progress if content changed
+        wpm: document.wpm,
+        updatedAt: new Date().toISOString(),
+      });
+
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save changes');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onClose();
+    } else if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      handleSave();
+    }
+  };
+
+  const wordCount = content.trim().split(/\s+/).filter(Boolean).length;
+  const contentChanged = content !== originalContent;
+  const titleChanged = title !== document?.title;
+  const hasChanges = contentChanged || titleChanged;
+
+  return (
+    <AnimatePresence>
+      {isOpen && document && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50"
+            onClick={onClose}
+          />
+          <motion.div
+            initial={{ opacity: 0, scale: 0.95, y: 20 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 20 }}
+            transition={{ duration: 0.2 }}
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            onKeyDown={handleKeyDown}
+          >
+            <div
+              className="w-full max-w-3xl bg-bg-elevated border border-border rounded-xl shadow-2xl shadow-black/40 max-h-[90vh] flex flex-col"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {/* Header */}
+              <div className="flex items-center justify-between p-4 border-b border-border shrink-0">
+                <div className="flex items-center gap-3">
+                  <div className="w-10 h-10 rounded-lg bg-amber-400/10 flex items-center justify-center">
+                    <FileText className="w-5 h-5 text-amber-400" />
+                  </div>
+                  <div>
+                    <h2 className="font-serif font-semibold text-lg text-text-primary">
+                      Edit Document
+                    </h2>
+                    <p className="text-sm text-text-secondary">
+                      {hasContent ? 'Modify title and content' : 'Content not available'}
+                    </p>
+                  </div>
+                </div>
+                <button
+                  onClick={onClose}
+                  disabled={isSaving}
+                  className="p-2 rounded-lg hover:bg-bg-surface transition-colors disabled:opacity-50"
+                >
+                  <X className="w-5 h-5 text-text-tertiary" />
+                </button>
+              </div>
+
+              {/* Content */}
+              <div className="p-4 space-y-4 overflow-y-auto flex-1">
+                {isLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <Loader2 className="w-6 h-6 text-amber-400 animate-spin" />
+                  </div>
+                ) : !hasContent ? (
+                  <div className="flex flex-col items-center justify-center py-12 text-center space-y-4">
+                    <div className="w-16 h-16 rounded-full bg-bg-surface flex items-center justify-center">
+                      <AlertCircle className="w-8 h-8 text-text-tertiary" />
+                    </div>
+                    <div>
+                      <h3 className="font-serif font-medium text-text-primary mb-2">
+                        Content Not Available
+                      </h3>
+                      <p className="text-sm text-text-secondary max-w-md">
+                        This document was created before content storage was added.
+                        Only the processed tokens exist. Editing is not available for legacy documents.
+                      </p>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    {/* Title Input */}
+                    <div className="space-y-2">
+                      <label htmlFor="edit-title" className="block text-sm font-medium text-text-primary">
+                        Title
+                      </label>
+                      <Input
+                        ref={titleInputRef}
+                        id="edit-title"
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                        placeholder="Enter document title..."
+                        disabled={isSaving}
+                        maxLength={200}
+                      />
+                    </div>
+
+                    {/* Content Textarea */}
+                    <div className="space-y-2 flex-1 flex flex-col">
+                      <div className="flex items-center justify-between">
+                        <label htmlFor="edit-content" className="block text-sm font-medium text-text-primary">
+                          Content
+                        </label>
+                        <span className="text-xs text-text-tertiary font-counter">
+                          {wordCount.toLocaleString()} words
+                        </span>
+                      </div>
+                      <Textarea
+                        id="edit-content"
+                        value={content}
+                        onChange={(e) => setContent(e.target.value)}
+                        placeholder="Paste your text here..."
+                        disabled={isSaving}
+                        className="min-h-[300px] resize-none font-serif"
+                      />
+                    </div>
+
+                    {/* Warning about progress reset */}
+                    {contentChanged && (
+                      <motion.div
+                        initial={{ opacity: 0, y: -10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        className="flex items-start gap-3 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg"
+                      >
+                        <AlertCircle className="w-5 h-5 text-amber-400 shrink-0 mt-0.5" />
+                        <div className="text-sm text-text-secondary">
+                          <span className="font-medium text-text-primary">Reading progress will be reset.</span>
+                          {' '}Your reading position will return to the beginning when you save changes to the content.
+                        </div>
+                      </motion.div>
+                    )}
+
+                    {/* Error Message */}
+                    {error && (
+                      <motion.div
+                        initial={{ opacity: 0, y: -10 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        className="p-3 bg-destructive/10 border border-destructive/30 rounded-lg text-destructive text-sm"
+                      >
+                        {error}
+                      </motion.div>
+                    )}
+                  </>
+                )}
+              </div>
+
+              {/* Footer */}
+              {hasContent && !isLoading && (
+                <div className="flex items-center justify-between gap-3 p-4 border-t border-border shrink-0">
+                  <p className="text-xs text-text-tertiary">
+                    Press <kbd className="px-1.5 py-0.5 bg-bg-surface rounded text-text-secondary">Cmd+Enter</kbd> to save
+                  </p>
+                  <div className="flex gap-3">
+                    <Button
+                      variant="outline"
+                      onClick={onClose}
+                      disabled={isSaving}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      onClick={handleSave}
+                      disabled={isSaving || !hasChanges}
+                      className="gap-2"
+                    >
+                      {isSaving ? (
+                        <>
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                          Saving...
+                        </>
+                      ) : (
+                        <>
+                          <Save className="w-4 h-4" />
+                          Save Changes
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/types/document.ts
+++ b/frontend/src/types/document.ts
@@ -12,6 +12,7 @@ export interface Document {
   shareToken?: string;
   expiresAt?: string;
   createdAt: string;
+  hasContent: boolean; // True if original content is stored (for editing)
 }
 
 export interface ReadingState {
@@ -41,4 +42,10 @@ export interface DocumentWithProgress extends Document {
 
 export interface UpdateDocumentRequest {
   title: string;
+  content?: string; // Optional: if provided, re-tokenizes and resets reading progress
+}
+
+export interface GetContentResponse {
+  content: string;
+  hasContent: boolean;
 }

--- a/frontend/src/views/LibraryView.tsx
+++ b/frontend/src/views/LibraryView.tsx
@@ -4,8 +4,9 @@ import { motion } from 'motion/react';
 import { Plus, Library, FileText } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { DocumentCard } from '../components/DocumentCard';
+import { EditDocumentModal } from '../components/EditDocumentModal';
 import { UserMenu } from '../components/UserMenu';
-import { listDocuments, updateDocument, deleteDocument } from '../api';
+import { listDocuments, deleteDocument } from '../api';
 import type { DocumentWithProgress } from '../types';
 
 function LibraryView() {
@@ -13,6 +14,7 @@ function LibraryView() {
   const [documents, setDocuments] = useState<DocumentWithProgress[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [editingDocument, setEditingDocument] = useState<DocumentWithProgress | null>(null);
 
   const fetchDocuments = useCallback(async () => {
     try {
@@ -30,10 +32,13 @@ function LibraryView() {
     fetchDocuments();
   }, [fetchDocuments]);
 
-  const handleRename = async (id: string, title: string) => {
-    await updateDocument(id, { title });
+  const handleEdit = (document: DocumentWithProgress) => {
+    setEditingDocument(document);
+  };
+
+  const handleUpdate = (updatedDoc: DocumentWithProgress) => {
     setDocuments((prev) =>
-      prev.map((doc) => (doc.id === id ? { ...doc, title } : doc))
+      prev.map((doc) => (doc.id === updatedDoc.id ? updatedDoc : doc))
     );
   };
 
@@ -127,7 +132,7 @@ function LibraryView() {
               <DocumentCard
                 key={doc.id}
                 document={doc}
-                onRename={handleRename}
+                onEdit={handleEdit}
                 onDelete={handleDelete}
                 animationDelay={index * 0.08}
               />
@@ -135,6 +140,13 @@ function LibraryView() {
           </div>
         )}
       </main>
+
+      <EditDocumentModal
+        isOpen={!!editingDocument}
+        onClose={() => setEditingDocument(null)}
+        document={editingDocument}
+        onUpdate={handleUpdate}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Allow users to edit both document title and content from the Library page via a modal dialog
- When content is changed, the document is re-tokenized and reading progress resets to beginning (preserving WPM preference)
- Old documents without stored content show "Edit unavailable" message for backward compatibility

## Changes

**Backend:**
- Add nullable `content` column to documents table (migration 007)
- Add `GetContent`/`UpdateContent` repository methods
- Add `GetDocumentContent`/`UpdateDocumentContent` service methods  
- Add `GET /documents/:id/content` endpoint
- Extend `PUT /documents/:id` to accept optional `content` field
- Add content size validation matching create limits

**Frontend:**
- Add `EditDocumentModal` component with title/content editing
- Update `DocumentCard` to use `onEdit` callback instead of inline editing
- Update `LibraryView` to manage modal state
- Add `getDocumentContent` API function
- Extend types for content operations

## Test plan

- [ ] Run database migration: `make db-migrate`
- [ ] Create a new document and verify it can be edited (both title and content)
- [ ] Edit content and verify reading progress resets to 0%
- [ ] Verify WPM preference is preserved after content edit
- [ ] Test old documents (if any exist) show "Edit unavailable" message
- [ ] Verify content size limits are enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)