### PR TITLE
feat(extension): bring Chrome extension UI to parity with web UI

### DIFF
--- a/apps/extension/src/sidepanel/App.tsx
+++ b/apps/extension/src/sidepanel/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { HomeView } from './views/HomeView';
 import { ReaderView } from './views/ReaderView';
 import { LibraryView } from './views/LibraryView';
@@ -8,15 +8,17 @@ type View = 'home' | 'reader' | 'library';
 export function App() {
   const [view, setView] = useState<View>('home');
   const [currentDocId, setCurrentDocId] = useState<string | null>(null);
+  const [autoPlay, setAutoPlay] = useState(false);
 
   // Listen for new documents from background script
   useEffect(() => {
     const checkPendingDocument = async () => {
-      const result = await chrome.storage.local.get('pendingDocument');
+      const result = await chrome.storage.local.get(['pendingDocument', 'autoPlay']);
       if (result.pendingDocument) {
         setCurrentDocId(result.pendingDocument);
+        setAutoPlay(result.autoPlay || false);
         setView('reader');
-        await chrome.storage.local.remove('pendingDocument');
+        await chrome.storage.local.remove(['pendingDocument', 'autoPlay']);
       }
     };
 
@@ -26,8 +28,10 @@ export function App() {
     const listener = (changes: { [key: string]: chrome.storage.StorageChange }) => {
       if (changes.pendingDocument?.newValue) {
         setCurrentDocId(changes.pendingDocument.newValue);
+        // Read autoPlay from changes object directly (avoids race condition)
+        setAutoPlay(changes.autoPlay?.newValue || false);
         setView('reader');
-        chrome.storage.local.remove('pendingDocument');
+        chrome.storage.local.remove(['pendingDocument', 'autoPlay']);
       }
     };
 
@@ -37,8 +41,14 @@ export function App() {
 
   const handleNavigate = (newView: View, docId?: string) => {
     if (docId) setCurrentDocId(docId);
+    setAutoPlay(false); // Reset autoPlay when navigating manually
     setView(newView);
   };
+
+  // Clear autoPlay after reader view has consumed it
+  const handleAutoPlayConsumed = useCallback(() => {
+    setAutoPlay(false);
+  }, []);
 
   return (
     <div className="min-h-screen bg-bg-base text-text-primary">
@@ -49,6 +59,8 @@ export function App() {
         <ReaderView
           docId={currentDocId}
           onBack={() => setView('library')}
+          autoPlay={autoPlay}
+          onAutoPlayConsumed={handleAutoPlayConsumed}
         />
       )}
       {view === 'library' && (

--- a/apps/extension/src/sidepanel/components/CompactControlBar.tsx
+++ b/apps/extension/src/sidepanel/components/CompactControlBar.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { Play, Pause } from 'lucide-react';
+import { motion } from 'motion/react';
+import { Button, Slider, ToggleGroup, ToggleGroupItem } from '@speed-reader/ui';
+
+interface CompactControlBarProps {
+  isPlaying: boolean;
+  wpm: number;
+  chunkSize: number;
+  onPlayPause: () => void;
+  onWpmChange: (wpm: number) => void;
+  onChunkSizeChange: (size: number) => void;
+}
+
+export const CompactControlBar = React.memo(function CompactControlBar({
+  isPlaying,
+  wpm,
+  chunkSize,
+  onPlayPause,
+  onWpmChange,
+  onChunkSizeChange,
+}: CompactControlBarProps) {
+  return (
+    <div className="flex flex-col gap-3 p-3 bg-bg-surface rounded-xl">
+      {/* Play button and WPM row */}
+      <div className="flex items-center gap-3">
+        <motion.div
+          whileTap={{ scale: 0.95 }}
+          transition={{ type: 'spring', stiffness: 400, damping: 17 }}
+        >
+          <Button
+            size="icon"
+            onClick={onPlayPause}
+            aria-label={isPlaying ? 'Pause' : 'Play'}
+            className="w-11 h-11 rounded-full bg-amber-500 hover:bg-amber-400 active:bg-amber-600 text-bg-deep shadow-[0_0_12px_rgba(240,166,35,0.3)] hover:shadow-[0_0_18px_rgba(240,166,35,0.5)] transition-shadow"
+          >
+            <motion.div
+              key={isPlaying ? 'pause' : 'play'}
+              initial={{ scale: 0.8, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ type: 'spring', stiffness: 500, damping: 25 }}
+            >
+              {isPlaying ? (
+                <Pause className="w-5 h-5" />
+              ) : (
+                <Play className="w-5 h-5 ml-0.5" />
+              )}
+            </motion.div>
+          </Button>
+        </motion.div>
+
+        <div className="flex-1 flex items-center gap-2">
+          <span className="text-[10px] font-counter font-medium text-text-tertiary uppercase tracking-widest">
+            WPM
+          </span>
+          <Slider
+            value={[wpm]}
+            min={100}
+            max={1000}
+            step={25}
+            onValueChange={([value]) => onWpmChange(value)}
+            className="flex-1"
+          />
+          <span className="min-w-9 font-counter text-xs font-semibold text-amber-400 tabular-nums">
+            {wpm}
+          </span>
+        </div>
+      </div>
+
+      {/* Chunk size row */}
+      <div className="flex items-center justify-center gap-2">
+        <span className="text-[10px] font-counter font-medium text-text-tertiary uppercase tracking-widest">
+          Words
+        </span>
+        <ToggleGroup
+          type="single"
+          value={String(chunkSize)}
+          onValueChange={(value) => value && onChunkSizeChange(Number(value))}
+          variant="outline"
+        >
+          {[1, 2, 3, 4].map((size) => (
+            <ToggleGroupItem
+              key={size}
+              value={String(size)}
+              aria-label={`Show ${size} word${size > 1 ? 's' : ''} at a time`}
+              className="w-7 h-7 text-xs font-counter font-medium"
+            >
+              {size}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+    </div>
+  );
+});

--- a/apps/extension/src/sidepanel/styles.css
+++ b/apps/extension/src/sidepanel/styles.css
@@ -52,6 +52,13 @@
   --color-input: #3d362c;
   --color-ring: #f0a623;
 
+  /* Radii */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-full: 9999px;
+
   /* Font families */
   --font-sans: 'Newsreader', Georgia, 'Times New Roman', serif;
   --font-serif: 'Newsreader', Georgia, 'Times New Roman', serif;


### PR DESCRIPTION
## Summary
- Add missing CSS radius variables for proper Tailwind component styling
- Implement auto-play when using context menu ("Speed Read Selection") or keyboard shortcut (Cmd/Ctrl+Shift+S)
- Create CompactControlBar component optimized for narrow sidebar layout
- Fix pivot character highlighting, focus line, WPM slider, and play button to match web UI

## Changes
- `apps/extension/src/sidepanel/styles.css` - Added CSS radius variables
- `apps/extension/src/background/service-worker.ts` - Added autoPlay flag to selection handlers
- `apps/extension/src/sidepanel/App.tsx` - Track autoPlay state, fixed race condition in storage listener
- `apps/extension/src/sidepanel/views/ReaderView.tsx` - Handle autoPlay prop with ref guard
- `apps/extension/src/sidepanel/components/CompactControlBar.tsx` - New compact control bar for sidebar

## Test plan
- [ ] Load extension in Chrome and verify pivot character shows copper glow
- [ ] Verify focus line appears below the word display
- [ ] Test WPM slider adjusts reading speed (100-1000 range)
- [ ] Test chunk size toggle (1-4 words)
- [ ] Select text on a webpage, right-click "Speed Read Selection" → should auto-play
- [ ] Use Cmd+Shift+S (Mac) / Ctrl+Shift+S (Windows) with text selected → should auto-play
- [ ] Verify play/pause button has spring animation matching web version

🤖 Generated with [Claude Code](https://claude.com/claude-code)